### PR TITLE
Workaround for MDX crlf issue

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# To work around MDX issues
+README.md text eol=lf

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -3,8 +3,8 @@ name: build-and-test
 on:
   pull_request:
   push:
-    branches-ignore:
-      - gh-pages
+    branches:
+      - main
 
 jobs:
   build:


### PR DESCRIPTION
[MDX](https://github.com/realworldocaml/mdx/issues/295) cannot handle crlf line endings.  This PR instructs git to use lf line endings for README.md as a workaround.

At the time of writing this there is still a problem on Windows as the threads library is not currently built correctly and so fails to load.  @dra27 says he might have a fix for this.

This PR also changes the github action workflow so that it is only run for pull requests and pushes to main to avoid running things twice.