### PR TITLE
[optimization]: make Var.t.value unboxed and specialize cutoff to avoid indirect calls in the majority case(which is physical equality)

### DIFF
--- a/lib/par_incr.ml
+++ b/lib/par_incr.ml
@@ -33,7 +33,7 @@ module Cutoff = struct
     | Eq of ('a -> 'a -> bool)
     | F of (oldval:'a -> newval:'a -> bool)
 
-  let attach cutoff t ctx e =
+  let[@inline] attach cutoff t ctx e =
     let tvar = t ctx e in
     tvar.cutoff <- cutoff;
     tvar
@@ -44,7 +44,8 @@ module Var = struct
 
   let null = Obj.magic (ref ())
 
-  let create ?(cutoff = Cutoff.Phys_equal) ?(to_s = Utils.undefined) x =
+  let[@inline] create ?(cutoff = Cutoff.Phys_equal) ?(to_s = Utils.undefined) x
+      =
     let v =
       {value = x; cutoff; to_string = to_s; readers = Reader_list.empty ()}
     in
@@ -54,26 +55,24 @@ module Var = struct
     {value = null; cutoff; to_string = to_s; readers = Reader_list.empty ()}
 
   let[@inline] set ({cutoff; value; readers; _} as t) x =
-    begin
-      if value == null then t.value <- x
-      else
-        let is_same =
-          match cutoff with
-          | Never -> false
-          | Always ->
-            true
-            (*Compiler can optimize Always and Never cases by just returning it
-              directly because of the way they are defined. Always will be
-              represented as 1(same as true) and Never will be represented as
-              0(same as false) *)
-          | Phys_equal -> x == value
-          | Eq f -> f value x
-          | F f -> f ~oldval:value ~newval:x
-        in
-        if not is_same then (
-          t.value <- x;
-          Reader_list.iter readers Rsp.RNode.mark_dirty)
-    end
+    if value == null then t.value <- x
+    else
+      let is_same =
+        match cutoff with
+        | Never -> false
+        | Always ->
+          true
+          (*Compiler can optimize Always and Never cases by just returning it
+            directly because of the way they are defined. Always will be
+            represented as 1(same as true) and Never will be represented as
+            0(same as false) *)
+        | Phys_equal -> x == value
+        | Eq f -> f value x
+        | F f -> f ~oldval:value ~newval:x
+      in
+      if not is_same then (
+        t.value <- x;
+        Reader_list.iter readers Rsp.RNode.mark_dirty)
 
   let[@inline] value t =
     if t.value == null then
@@ -82,18 +81,21 @@ module Var = struct
 
   let[@inline] cutoff {cutoff; _} = cutoff
 
-  let attach_cutoff (t : 'a t) cutoff =
+  let[@inline] attach_cutoff (t : 'a t) cutoff =
     if t.cutoff != cutoff then t.cutoff <- cutoff
 
-  let attach_to_string (t : 'a t) f =
+  let[@inline] attach_to_string (t : 'a t) f =
     if t.to_string != f then t.to_string <- f else ()
 
-  let add_reader {readers; _} r = Reader_list.add_reader readers r
-  let remove_reader {readers; _} r = Reader_list.remove_reader readers r
-  let num_readers {readers; _} = Reader_list.length readers
-  let to_s t = t |> value |> t.to_string
-  let get_to_string {to_string; _} = to_string
-  let watch x _ _ = x
+  let[@inline] add_reader {readers; _} r = Reader_list.add_reader readers r
+
+  let[@inline] remove_reader {readers; _} r =
+    Reader_list.remove_reader readers r
+
+  let[@inline] num_readers {readers; _} = Reader_list.length readers
+  let[@inline] to_s t = t |> value |> t.to_string
+  let[@inline] get_to_string {to_string; _} = to_string
+  let[@inline] watch x _ _ = x
 
   module Syntax = struct
     let ( := ) = set
@@ -105,89 +107,83 @@ let return x _ _ = Var.create x
 
 let map ?(cutoff = Cutoff.Phys_equal) ~(fn : 'a -> 'b) (t : 'a t) (ctx : ctx)
     (e : executor) =
-  begin
-    let open Types in
-    let left = Rsp.make_empty `S in
-    let x = t left e in
-    let y = Var.empty ~cutoff ~to_s:Utils.undefined () in
-    let read_fn (type a) : a action -> a = function
-      | Update -> Var.set y (Var.value x |> fn)
-      | Remove self -> Var.remove_reader x self
-      | Show -> "map: " ^ Var.to_s y
-      | Count cntr -> cntr.map <- cntr.map + 1
-    in
+  let open Types in
+  let left = Rsp.make_empty `S in
+  let x = t left e in
+  let y = Var.empty ~cutoff ~to_s:Utils.undefined () in
+  let read_fn (type a) : a action -> a = function
+    | Update -> Var.set y (Var.value x |> fn)
+    | Remove self -> Var.remove_reader x self
+    | Show -> "map: " ^ Var.to_s y
+    | Count cntr -> cntr.map <- cntr.map + 1
+  in
 
-    let read_x = RNode.make ~fn:RNode.{fn = read_fn} in
-    Var.add_reader x read_x;
-    Rsp.set_exn ctx `Left (Rsp.prune left);
-    Rsp.set_exn ctx `Right read_x;
-    read_x.fn Update;
-    y
-  end
+  let read_x = RNode.make ~fn:RNode.{fn = read_fn} in
+  Var.add_reader x read_x;
+  Rsp.set_exn ctx `Left (Rsp.prune left);
+  Rsp.set_exn ctx `Right read_x;
+  read_x.fn Update;
+  y
 
 let combine (a : 'a t) (b : 'b t) ctx e =
-  begin
-    let open Types in
-    let ll = Rsp.make_empty `S in
-    let lr = Rsp.make_empty `S in
-    let x = a ll e in
-    let y = b lr e in
-    let xy = Var.empty ~cutoff:Phys_equal ~to_s:Utils.undefined () in
-    let read_fn_xy (type a) : a action -> a = function
-      | Update -> Var.set xy (Var.value x, Var.value y)
-      | Remove self ->
-        Var.remove_reader x self;
-        Var.remove_reader y self
-      | Show -> "combine: " ^ Var.to_s xy
-      | Count cntr -> cntr.combine <- cntr.combine + 1
-    in
-    let read_xy = RNode.make ~fn:RNode.{fn = read_fn_xy} in
-    Var.add_reader x read_xy;
-    Var.add_reader y read_xy;
-    let left = Rsp.make_node `S ~l:(Rsp.prune ll) ~r:(Rsp.prune lr) in
-    Rsp.set_exn ctx `Left left;
-    Rsp.set_exn ctx `Right read_xy;
-    read_xy.fn Update;
-    xy
-  end
+  let open Types in
+  let ll = Rsp.make_empty `S in
+  let lr = Rsp.make_empty `S in
+  let x = a ll e in
+  let y = b lr e in
+  let xy = Var.empty ~cutoff:Phys_equal ~to_s:Utils.undefined () in
+  let read_fn_xy (type a) : a action -> a = function
+    | Update -> Var.set xy (Var.value x, Var.value y)
+    | Remove self ->
+      Var.remove_reader x self;
+      Var.remove_reader y self
+    | Show -> "combine: " ^ Var.to_s xy
+    | Count cntr -> cntr.combine <- cntr.combine + 1
+  in
+  let read_xy = RNode.make ~fn:RNode.{fn = read_fn_xy} in
+  Var.add_reader x read_xy;
+  Var.add_reader y read_xy;
+  let left = Rsp.make_node `S ~l:(Rsp.prune ll) ~r:(Rsp.prune lr) in
+  Rsp.set_exn ctx `Left left;
+  Rsp.set_exn ctx `Right read_xy;
+  read_xy.fn Update;
+  xy
 
 let par ~left ~right ctx e =
-  begin
-    let open Types in
-    let (lres, ll), (rres, lr) =
-      e.par_do
-        (fun () ->
-          let ll = Rsp.make_empty `S in
-          let lres = left ll e in
-          (lres, Rsp.prune ll))
-        (fun () ->
-          let lr = Rsp.make_empty `S in
-          let rres = right lr e in
-          (rres, Rsp.prune lr))
-    in
-    let lr_comb =
-      Var.empty ~cutoff:Phys_equal
-        ~to_s:
-          (Utils.combine_to_s (Var.get_to_string lres) (Var.get_to_string rres))
-        ()
-    in
-    let read_fn_lr_comb (type a) : a action -> a = function
-      | Update -> Var.set lr_comb (Var.value lres, Var.value rres)
-      | Remove self ->
-        Var.remove_reader lres self;
-        Var.remove_reader rres self
-      | Show -> "par: " ^ Var.to_s lr_comb
-      | Count cntr -> cntr.par_do <- cntr.par_do + 1
-    in
-    let read_lr = RNode.make ~fn:RNode.{fn = read_fn_lr_comb} in
-    Var.add_reader lres read_lr;
-    Var.add_reader rres read_lr;
-    let left = Rsp.make_node `P ~l:ll ~r:lr in
-    Rsp.set_exn ctx `Left left;
-    Rsp.set_exn ctx `Right read_lr;
-    read_lr.fn Update;
-    lr_comb
-  end
+  let open Types in
+  let (lres, ll), (rres, lr) =
+    e.par_do
+      (fun () ->
+        let ll = Rsp.make_empty `S in
+        let lres = left ll e in
+        (lres, Rsp.prune ll))
+      (fun () ->
+        let lr = Rsp.make_empty `S in
+        let rres = right lr e in
+        (rres, Rsp.prune lr))
+  in
+  let lr_comb =
+    Var.empty ~cutoff:Phys_equal
+      ~to_s:
+        (Utils.combine_to_s (Var.get_to_string lres) (Var.get_to_string rres))
+      ()
+  in
+  let read_fn_lr_comb (type a) : a action -> a = function
+    | Update -> Var.set lr_comb (Var.value lres, Var.value rres)
+    | Remove self ->
+      Var.remove_reader lres self;
+      Var.remove_reader rres self
+    | Show -> "par: " ^ Var.to_s lr_comb
+    | Count cntr -> cntr.par_do <- cntr.par_do + 1
+  in
+  let read_lr = RNode.make ~fn:RNode.{fn = read_fn_lr_comb} in
+  Var.add_reader lres read_lr;
+  Var.add_reader rres read_lr;
+  let left = Rsp.make_node `P ~l:ll ~r:lr in
+  Rsp.set_exn ctx `Left left;
+  Rsp.set_exn ctx `Right read_lr;
+  read_lr.fn Update;
+  lr_comb
 
 let map2 ?(cutoff = Types.Phys_equal) ?(mode = `Seq) ~fn x y ctx e =
   let xy =
@@ -201,10 +197,11 @@ let dump_tree file c =
   Out_channel.with_open_text file (fun oc -> Rsp.to_d2 oc c.root |> ignore)
 
 let destroy_comp comp =
-  Rsp.destroy comp.root;
-  comp.root <- Types.nil_tree
+  let root = comp.root in
+  comp.root <- Types.nil_tree;
+  Rsp.destroy root
 
-let delay f c e = f () c e [@@inline]
+let[@inline] delay f c e = f () c e
 
 module Debug = struct
   let attach ~fn t c e =
@@ -214,58 +211,50 @@ module Debug = struct
 end
 
 let bind ~fn x ctx e =
-  begin
-    let open Types in
-    let r = Rsp.set_and_get_exn ctx `Right (Rsp.make_empty `S) in
-    let ll = Rsp.make_empty `S in
-    let xvar = x ll e in
-    let y = Var.empty ~cutoff:Phys_equal ~to_s:Utils.undefined () in
-    let read_fn_xvar (type a) : a action -> a = function
-      | Update -> begin
-        let y' = fn (Var.value xvar) in
-        let rl = Rsp.make_empty `S in
-        let yvar' = y' rl e in
-        let () = Rsp.set_exn r `Left (Rsp.prune rl) in
-        let read_fn_yvar' (type a) : a action -> a = function
-          | Update ->
-            Var.set y (Var.value yvar');
-            Var.attach_cutoff y (Var.cutoff yvar');
-            Var.attach_to_string y (Var.get_to_string yvar')
-          | Remove self -> Var.remove_reader yvar' self
-          | Show -> "inner-bind: " ^ Var.to_s y
-          | Count _ -> () (*Not going to count this*)
-        in
-        let read_yvar' = RNode.make ~fn:RNode.{fn = read_fn_yvar'} in
-        Var.add_reader yvar' read_yvar';
-        Rsp.set_exn r `Right read_yvar';
-        read_yvar'.fn Update
-      end
-      | Remove self -> Var.remove_reader xvar self
-      | Show -> "outer-bind: " ^ Var.to_s xvar
-      | Count cntr -> cntr.bind <- cntr.bind + 1
-    in
-    let read_xvar = RNode.make ~fn:RNode.{fn = read_fn_xvar} in
-    Var.add_reader xvar read_xvar;
-    let l = Rsp.make_node `S ~l:(Rsp.prune ll) ~r:read_xvar in
-    Rsp.set_exn ctx `Left l;
-    read_xvar.fn Update;
-    y
-  end
+  let open Types in
+  let r = Rsp.set_and_get_exn ctx `Right (Rsp.make_empty `S) in
+  let ll = Rsp.make_empty `S in
+  let xvar = x ll e in
+  let y = Var.empty ~cutoff:Phys_equal ~to_s:Utils.undefined () in
+  let read_fn_xvar (type a) : a action -> a = function
+    | Update -> begin
+      let y' = fn (Var.value xvar) in
+      let rl = Rsp.make_empty `S in
+      let yvar' = y' rl e in
+      let () = Rsp.set_exn r `Left (Rsp.prune rl) in
+      let read_fn_yvar' (type a) : a action -> a = function
+        | Update ->
+          Var.set y (Var.value yvar');
+          Var.attach_cutoff y (Var.cutoff yvar');
+          Var.attach_to_string y (Var.get_to_string yvar')
+        | Remove self -> Var.remove_reader yvar' self
+        | Show -> "inner-bind: " ^ Var.to_s y
+        | Count _ -> () (*Not going to count this*)
+      in
+      let read_yvar' = RNode.make ~fn:RNode.{fn = read_fn_yvar'} in
+      Var.add_reader yvar' read_yvar';
+      Rsp.set_exn r `Right read_yvar';
+      read_yvar'.fn Update
+    end
+    | Remove self -> Var.remove_reader xvar self
+    | Show -> "outer-bind: " ^ Var.to_s xvar
+    | Count cntr -> cntr.bind <- cntr.bind + 1
+  in
+  let read_xvar = RNode.make ~fn:RNode.{fn = read_fn_xvar} in
+  Var.add_reader xvar read_xvar;
+  let l = Rsp.make_node `S ~l:(Rsp.prune ll) ~r:read_xvar in
+  Rsp.set_exn ctx `Left l;
+  read_xvar.fn Update;
+  y
 
 let run ~(executor : executor) f =
-  begin
-    let root = Rsp.make_root () in
-    let run' = executor.run in
-    let f' () = f root executor in
-    let var = run' f' in
-    {root; var; e = executor}
-  end
+  let root = Rsp.make_root () in
+  let run' = executor.run in
+  let f' () = f root executor in
+  let var = run' f' in
+  {root; var; e = executor}
 
-let propagate comp =
-  begin
-    Rsp.propagate_root comp.root comp.e
-  end
-
+let propagate comp = Rsp.propagate_root comp.root comp.e
 let get_stat comp = Rsp.get_stats comp.root
 
 module Syntax = struct

--- a/lib/par_incr.ml
+++ b/lib/par_incr.ml
@@ -1,4 +1,4 @@
-let null = Obj.magic "nullptr"
+let null = Obj.magic (ref ())
 
 type 'a var = {
   mutable value : 'a;

--- a/lib/par_incr.ml
+++ b/lib/par_incr.ml
@@ -1,5 +1,3 @@
-let null = Obj.magic (ref ())
-
 type 'a var = {
   mutable value : 'a;
   mutable cutoff : 'a Types.cutoff;
@@ -43,6 +41,8 @@ end
 
 module Var = struct
   type 'a t = 'a var
+
+  let null = Obj.magic (ref ())
 
   let create ?(cutoff = Cutoff.Phys_equal) ?(to_s = Utils.undefined) x =
     let v =

--- a/lib/par_incr.mli
+++ b/lib/par_incr.mli
@@ -73,14 +73,25 @@ type executor = Types.executor = {
 *)
 
 module Cutoff : sig
+  (**Defines different computation cutoff strategies*)
   type 'a t =
-    | Always
-    | Never
+    | Always  (**Always cut-off the computation*)
+    | Never  (** Never cut-off the computation*)
     | Phys_equal
+        (** Cut off the computation based on physical equality [(==)] *)
     | Eq of ('a -> 'a -> bool)
+        (** Cutoff the computation based on the function passed*)
     | F of (oldval:'a -> newval:'a -> bool)
+        (** Same functionality as [Eq] but the equality function uses named
+            arguments*)
 
   val attach : 'a t -> 'a incremental -> 'a incremental
+  (** [Cutoff.attach cutoff incr] attaches the given cutoff strategy to the
+      incremental [incr]. The default cutoff in most cases is `Phys_equal`. So,
+      this is useful in cases where you want somewhat different cutoff
+      condition. Take floating point related computations for example, you may
+      choose to ignore difference in values within some delta. For such cases,
+      you can use this. *)
 end
 
 (** Defines the type and various operations for modifiable values. *)
@@ -92,8 +103,8 @@ module Var : sig
 
   val create : ?cutoff:'a Cutoff.t -> ?to_s:('a -> string) -> 'a -> 'a t
   (** [Var.create x] creates a [Var.t] with value [x]. Optionally you can
-      specify [eq] and [to_s] parameters as well. Default for [eq] is [(==)] and
-      it's recommended to pass [eq] wherever the default doesn't work. *)
+      specify [cutoff] and [to_s] parameters as well. Default for [cutoff] is [Phys_equal] and
+      it's recommended to pass [cutoff] wherever the default doesn't work. *)
 
   val set : 'a t -> 'a -> unit
   (** [Var.set t x] sets the value of [t] to [x]. In case [x] is same as the old
@@ -145,8 +156,8 @@ val return : 'a -> 'a t
 (** [return x] returns an instance of ['a incremental] from [x] of type ['a]. *)
 
 val map : ?cutoff:'b Cutoff.t -> fn:('a -> 'b) -> 'a t -> 'b t
-(** [map ~fn a] maps the internal value of [a] to [fn]. Default [eq] is
-    [(==)]. *)
+(** [map ~fn a] maps the internal value of [a] to [fn]. Default [cutoff] is
+    [Phys_equal]. *)
 
 val map2 :
   ?cutoff:'c Cutoff.t ->
@@ -158,7 +169,7 @@ val map2 :
 (** [map2 ~fn ?(mode=`Seq) a b] is a convenient function to [map] over two
     [incremental]s.  If [mode] is [`Seq], it computes [a] and [b] sequentially,
     but if it is [`Par], computing [a] and [b] happens in parallel (it's ran
-    with {!executor}s {!par_do} function). Default [eq] is [(==)]. *)
+    with {!executor}s {!par_do} function). Default [cutoff] is [Phys_equal]. *)
 
 val combine : 'a t -> 'b t -> ('a * 'b) t
 (** [combine a b] is useful function to combine two [incremental]'s into one. *)
@@ -220,9 +231,9 @@ module Syntax : sig
   val ( let+ ) : 'a t -> ('a -> 'b) -> 'b t
   (** Syntactic sugar for {!map}.
 
-      {b NOTE}: You can't provide your own [eq] function when using [Syntax]
-      module. You may use {!Eq.attach} to add it to the resultant [incremental],
-      but there's no way to pass it as parameter initially like with [map]. *)
+      {b NOTE}: You can't provide your own [cutoff] when using [Syntax] module.
+      You may use {!Cutoff.attach} to add it to the resultant [incremental], but
+      there's no way to pass it as parameter initially like with [map]. *)
 
   val ( and+ ) : 'a t -> 'b t -> ('a * 'b) t
   (** Syntactic sugar for {!combine}. Recommended to be used together with

--- a/lib/par_incr.mli
+++ b/lib/par_incr.mli
@@ -75,8 +75,8 @@ type executor = Types.executor = {
 module Cutoff : sig
   (**Defines different computation cutoff strategies*)
   type 'a t =
+    | Never  (**Never cut-off the computation*)
     | Always  (**Always cut-off the computation*)
-    | Never  (** Never cut-off the computation*)
     | Phys_equal
         (** Cut off the computation based on physical equality [(==)] *)
     | Eq of ('a -> 'a -> bool)

--- a/lib/rsp.ml
+++ b/lib/rsp.ml
@@ -2,7 +2,7 @@ module RNode = struct
   open Types
 
   type t = rnode
-  type show_fn_wrapper = {fn : 'a. 'a action -> 'a}
+  type show_fn_wrapper = {fn : 'a. 'a action -> 'a} [@@unboxed]
 
   let[@inline] make ~fn:{fn} =
     {

--- a/lib/rsp.ml
+++ b/lib/rsp.ml
@@ -25,8 +25,8 @@ open Types
 
 type t = comp_tree
 
-let empty = Types.nil_tree
 let nil_tree = Types.nil_tree
+let empty = nil_tree
 
 let[@inline] set_parent_exn ~c ~p =
   if c != nil_tree && not (Utils.is_root c.flags) then c.par <- p

--- a/lib/rsp.ml
+++ b/lib/rsp.ml
@@ -13,19 +13,16 @@ module RNode = struct
       fn;
     }
 
-  let[@inline] mark_dirty ({flags; par; _} as t) =
-    begin
-      if not (Utils.is_marked flags) then (
-        t.flags <- Utils.make_marked flags;
-        set_mark par)
-    end
+  let mark_dirty ({flags; par; _} as t) =
+    if not (Utils.is_marked flags) then (
+      t.flags <- Utils.make_marked flags;
+      set_mark par)
 end
 
 open Types
 
 type t = comp_tree
 
-let nil_tree = Types.nil_tree
 let empty = nil_tree
 
 let[@inline] set_parent_exn ~c ~p =
@@ -114,33 +111,25 @@ let[@inline] make_node ~l ~r typ =
     set_parent_exn ~c:r ~p:nd;
     nd
 
-(* let make_rnode rnd = R rnd *)
-
 let[@inline] is_marked c = c != nil_tree && Utils.is_marked c.flags
 
 let rec propagate_exn comp e =
-  (* if comp == nil_tree then () *)
-  (* else  *)
-  begin
-    let {left; right; fn; flags; _} = comp in
-    let masked_flag = Utils.masked flags in
-    (* if Utils.is_marked flag then begin *)
-    if masked_flag = Utils.r_flag then fn Update
-    else if masked_flag = Utils.p_flag && is_marked left && is_marked right then
-      let _ =
-        e.par_do
-          (fun () -> propagate_exn left e)
-          (fun () -> propagate_exn right e)
-      in
-      ()
-    else begin
-      (* Root is impossible case *)
-      if masked_flag = Utils.root_flag then Utils.impossible ();
-      if is_marked left then propagate_exn left e;
-      if is_marked right then propagate_exn right e
-    end;
-    (* end; *)
-    comp.flags <- masked_flag
+  let {left; right; fn; flags; _} = comp in
+  let masked_flag = Utils.masked flags in
+  comp.flags <- masked_flag;
+  if masked_flag = Utils.r_flag then fn Update
+  else if masked_flag = Utils.p_flag && is_marked left && is_marked right then
+    let _ =
+      e.par_do
+        (fun () -> propagate_exn left e)
+        (fun () -> propagate_exn right e)
+    in
+    ()
+  else begin
+    (* Root is impossible case *)
+    if masked_flag = Utils.root_flag then Utils.impossible ();
+    if is_marked left then propagate_exn left e;
+    if is_marked right then propagate_exn right e
   end
 
 let propagate_root comp e =
@@ -157,12 +146,11 @@ let propagate_root comp e =
   end
 
 let[@inline] set_and_get_exn t dir child =
-  (set_exn [@inlined]) t dir child;
+  set_exn t dir child;
   child
 
 let to_d2 ?(cnt = ref 0) (oc : Out_channel.t) =
-  (* let cnt = ref 0 in *)
-  let[@inline] incr_and_get cnt =
+  let incr_and_get cnt =
     incr cnt;
     !cnt
   in

--- a/lib/types.ml
+++ b/lib/types.ml
@@ -1,6 +1,6 @@
 type 'a cutoff =
-  | Always
   | Never
+  | Always
   | Phys_equal
   | Eq of ('a -> 'a -> bool)
   | F of (oldval:'a -> newval:'a -> bool)

--- a/lib/types.ml
+++ b/lib/types.ml
@@ -1,3 +1,10 @@
+type 'a cutoff =
+  | Always
+  | Never
+  | Phys_equal
+  | Eq of ('a -> 'a -> bool)
+  | F of (oldval:'a -> newval:'a -> bool)
+
 type comp_tree = {
   mutable par : comp_tree;
   mutable flags : int;

--- a/lib/utils.ml
+++ b/lib/utils.ml
@@ -8,7 +8,6 @@ let mask = 3
 let[@inline] deref t =
   match t with Some x -> x | None -> failwith "deref on None failed"
 
-let[@inline] combine_eq eq1 eq2 (a', b') (a'', b'') = eq1 a' a'' && eq2 b' b''
 let[@inline] impossible () = failwith "Impossible case"
 let undefined _ = "var"
 

--- a/test/filter.ml
+++ b/test/filter.ml
@@ -30,9 +30,9 @@ type 'a lst = Nil | Cons of {value : 'a; mutable rest : 'a lst}
 let[@tail_mod_cons] rec lst_to_list l =
   match l with Nil -> [] | Cons {value; rest} -> value :: lst_to_list rest
 
-let lst_eq a b =
-  let x, _ = a in
-  let y, _ = b in
+let lst_eq oldval newval =
+  let x, _ = oldval in
+  let y, _ = newval in
   match (x, y) with Nil, Nil -> true | _ -> false
 
 let set_rest lst rest = match lst with Nil -> () | Cons l -> l.rest <- rest
@@ -55,7 +55,7 @@ let combine_fn (x, xlast) (y, ylast) =
 
 let filter ~mode ~fn (xs : int Incr.t list) =
   let f : 'a -> (int -> 'a) -> ('a -> 'a -> 'a) -> int Incr.t list -> 'a t =
-    Utils.reduce_lst ~eq:lst_eq ~mode
+    Utils.reduce_lst ~cutoff:(Eq lst_eq) ~mode
   in
   f (Nil, Nil) (one_fn fn) combine_fn xs
 

--- a/test/incr_test.ml
+++ b/test/incr_test.ml
@@ -277,6 +277,7 @@ let bind_test () =
 
   let () = Var.set cond true in
   let () = propagate weird_not_computation in
+
   (*if then branch means just two reader for the cond variable*)
   Alcotest.(check int) reader_check 2 (Var.num_readers cond);
   Alcotest.(check int) reader_check 0 (Var.num_readers true_const);


### PR DESCRIPTION
I've added the benchmarks below and they show decent improvement over the current version(for which the benchmarks lie [here](https://github.com/ocaml-multicore/par_incr/pull/2) ). 


## filter

```bash
NUM_DOMAINS=2 RUNS=10 bash bench_runner.sh filter.exe 1000 100000 "i*10" 1
+ dune exec --release -- test/filter.exe -r 10 -n 1000 -c 10 -d 2
# Filtering list of size: 1000 | 10 elements changed in propagation | Domains spawned: 2
## Initial computation
Name                          Avg                Median             Runs     Max time           Min time
static-filter                 0.01261 ms         0.01144 ms         10       0.02598 ms         0.007152 ms
incr-seq-filter-initial-cons  0.2218 ms          0.2089 ms          10       0.3130 ms          0.1950 ms
incr-par-filter-initial-cons  0.3302 ms          0.3160 ms          10       0.4730 ms          0.2901 ms
current-incr-filter-init-cons 0.4548 ms          0.4354 ms          10       0.5970 ms          0.3762 ms
js-incr-filter-init-cons      0.5043 ms          0.4869 ms          10       0.6849 ms          0.4189 ms
## Change propagation
Name                            Avg                Median             Runs     Max time           Min time
js-incr-filter-change-prop      0.01709 ms         0.01716 ms         10       0.02479 ms         0.006198 ms
incr-seq-filter-change-prop     0.01826 ms         0.01788 ms         10       0.02980 ms         0.008106 ms
incr-par-filter-change-prop     0.02560 ms         0.02503 ms         10       0.04005 ms         0.01692 ms
current-incr-filter-change-prop 0.04355 ms         0.04434 ms         10       0.05602 ms         0.02193 ms
+ dune exec --release -- test/filter.exe -r 10 -n 10000 -c 100 -d 2
# Filtering list of size: 10000 | 100 elements changed in propagation | Domains spawned: 2
## Initial computation
Name                          Avg                Median             Runs     Max time           Min time
static-filter                 0.1069 ms          0.09691 ms         10       0.1490 ms          0.09489 ms
incr-par-filter-initial-cons  9.7951 ms          9.7054 ms          10       10.9479 ms         9.1121 ms
incr-seq-filter-initial-cons  9.7994 ms          10.5044 ms         10       11.6369 ms         7.2729 ms
js-incr-filter-init-cons      13.5192 ms         13.2409 ms         10       15.9008 ms         12.6709 ms
current-incr-filter-init-cons 15.6859 ms         15.9019 ms         10       18.5000 ms         10.3690 ms
## Change propagation
Name                            Avg                Median             Runs     Max time           Min time
js-incr-filter-change-prop      0.1663 ms          0.1718 ms          10       0.1988 ms          0.06818 ms
incr-par-filter-change-prop     0.1750 ms          0.1754 ms          10       0.2031 ms          0.1389 ms
incr-seq-filter-change-prop     0.2218 ms          0.2214 ms          10       0.2620 ms          0.1840 ms
current-incr-filter-change-prop 0.6251 ms          0.6095 ms          10       0.8878 ms          0.4270 ms
+ dune exec --release -- test/filter.exe -r 10 -n 100000 -c 1000 -d 2
# Filtering list of size: 100000 | 1000 elements changed in propagation | Domains spawned: 2
## Initial computation
Name                          Avg                Median             Runs     Max time           Min time
static-filter                 2.7430 ms          2.5501 ms          10       4.1971 ms          2.4631 ms
incr-par-filter-initial-cons  85.2566 ms         82.9846 ms         10       99.4248 ms         79.7479 ms
incr-seq-filter-initial-cons  86.06116 ms        79.1894 ms         10       105.6149 ms        78.1559 ms
js-incr-filter-init-cons      149.9191 ms        147.2380 ms        10       172.005176 ms      144.6549 ms
current-incr-filter-init-cons 174.2549 ms        172.1415 ms        10       192.6038 ms        156.9950 ms
## Change propagation
Name                            Avg                Median             Runs     Max time           Min time
incr-par-filter-change-prop     1.6911 ms          1.6820 ms          10       1.9271 ms          1.4901 ms
js-incr-filter-change-prop      2.3152 ms          2.3045 ms          10       2.8789 ms          1.9359 ms
incr-seq-filter-change-prop     2.9965 ms          3.02851 ms         10       3.2231 ms          2.5010 ms
current-incr-filter-change-prop 13.5433 ms         14.1394 ms         10       15.1331 ms         8.2099 ms


NUM_DOMAINS=4 RUNS=10 bash bench_runner.sh filter.exe 1000 100000 "i*10" 1
+ dune exec --release -- test/filter.exe -r 10 -n 1000 -c 10 -d 4
# Filtering list of size: 1000 | 10 elements changed in propagation | Domains spawned: 4
## Initial computation
Name                          Avg                Median             Runs     Max time           Min time
static-filter                 0.01022 ms         0.009059 ms        10       0.01692 ms         0.006914 ms
incr-seq-filter-initial-cons  0.2655 ms          0.2269 ms          10       0.5049 ms          0.2009 ms
incr-par-filter-initial-cons  0.3624 ms          0.3424 ms          10       0.5071 ms          0.2889 ms
current-incr-filter-init-cons 0.4709 ms          0.4464 ms          10       0.6690 ms          0.3478 ms
js-incr-filter-init-cons      0.5165 ms          0.4999 ms          10       0.6370 ms          0.4150 ms
## Change propagation
Name                            Avg                Median             Runs     Max time           Min time
incr-seq-filter-change-prop     0.01704 ms         0.01502 ms         10       0.02789 ms         0.01001 ms
js-incr-filter-change-prop      0.01754 ms         0.01692 ms         10       0.02384 ms         0.006914 ms
incr-par-filter-change-prop     0.02851 ms         0.02658 ms         10       0.04696 ms         0.02002 ms
current-incr-filter-change-prop 0.04830 ms         0.05090 ms         10       0.06294 ms         0.02002 ms
+ dune exec --release -- test/filter.exe -r 10 -n 10000 -c 100 -d 4
# Filtering list of size: 10000 | 100 elements changed in propagation | Domains spawned: 4
## Initial computation
Name                          Avg                Median             Runs     Max time           Min time
static-filter                 0.2769 ms          0.1069 ms          10       1.8198 ms          0.09679 ms
incr-par-filter-initial-cons  7.5495 ms          7.4065 ms          10       9.7811 ms          6.3300 ms
incr-seq-filter-initial-cons  9.1079 ms          8.7854 ms          10       12.2442 ms         6.9589 ms
current-incr-filter-init-cons 13.4696 ms         13.7075 ms         10       16.08204 ms        9.1338 ms
js-incr-filter-init-cons      14.6072 ms         14.3885 ms         10       16.3509 ms         13.7469 ms
## Change propagation
Name                            Avg                Median             Runs     Max time           Min time
incr-par-filter-change-prop     0.1436 ms          0.1399 ms          10       0.1649 ms          0.1130 ms
js-incr-filter-change-prop      0.1730 ms          0.1820 ms          10       0.1931 ms          0.07820 ms
incr-seq-filter-change-prop     0.2136 ms          0.2160 ms          10       0.2431 ms          0.1590 ms
current-incr-filter-change-prop 0.6144 ms          0.6515 ms          10       0.6701 ms          0.4081 ms
+ dune exec --release -- test/filter.exe -r 10 -n 100000 -c 1000 -d 4
# Filtering list of size: 100000 | 1000 elements changed in propagation | Domains spawned: 4
## Initial computation
Name                          Avg                Median             Runs     Max time           Min time
static-filter                 2.6028 ms          2.5619 ms          10       3.09705 ms         2.3748 ms
incr-par-filter-initial-cons  75.4290 ms         76.7600 ms         10       83.5659 ms         64.9430 ms
incr-seq-filter-initial-cons  86.5662 ms         89.9484 ms         10       100.7888 ms        70.8792 ms
js-incr-filter-init-cons      154.6686 ms        151.5344 ms        10       174.07202 ms       146.4190 ms
current-incr-filter-init-cons 159.8216 ms        151.1025 ms        10       222.03707 ms       139.3990 ms
## Change propagation
Name                            Avg                Median             Runs     Max time           Min time
incr-par-filter-change-prop     1.4409 ms          1.2865 ms          10       2.8970 ms          1.1761 ms
js-incr-filter-change-prop      2.3307 ms          2.2724 ms          10       2.7718 ms          2.1271 ms
incr-seq-filter-change-prop     2.9726 ms          2.9824 ms          10       3.2739 ms          2.5830 ms
current-incr-filter-change-prop 12.8150 ms         13.3589 ms         10       14.5158 ms         8.2941 ms


NUM_DOMAINS=6 RUNS=10 bash bench_runner.sh filter.exe 1000 100000 "i*10" 1
+ dune exec --release -- test/filter.exe -r 10 -n 1000 -c 10 -d 6
# Filtering list of size: 1000 | 10 elements changed in propagation | Domains spawned: 6
## Initial computation
Name                          Avg                Median             Runs     Max time           Min time
static-filter                 0.01111 ms         0.01001 ms         10       0.01692 ms         0.009059 ms
incr-seq-filter-initial-cons  0.2236 ms          0.2214 ms          10       0.2520 ms          0.2100 ms
incr-par-filter-initial-cons  0.3387 ms          0.3325 ms          10       0.3969 ms          0.2949 ms
current-incr-filter-init-cons 0.4947 ms          0.4780 ms          10       0.6229 ms          0.3850 ms
js-incr-filter-init-cons      0.5513 ms          0.5221 ms          10       0.8361 ms          0.4398 ms
## Change propagation
Name                            Avg                Median             Runs     Max time           Min time
incr-seq-filter-change-prop     0.01685 ms         0.01502 ms         10       0.02479 ms         0.01192 ms
js-incr-filter-change-prop      0.01809 ms         0.01907 ms         10       0.02503 ms         0.005006 ms
current-incr-filter-change-prop 0.04377 ms         0.04553 ms         10       0.05483 ms         0.02408 ms
incr-par-filter-change-prop     0.1005 ms          0.03695 ms         10       0.6840 ms          0.01788 ms
+ dune exec --release -- test/filter.exe -r 10 -n 10000 -c 100 -d 6
# Filtering list of size: 10000 | 100 elements changed in propagation | Domains spawned: 6
## Initial computation
Name                          Avg                Median             Runs     Max time           Min time
static-filter                 0.09877 ms         0.09799 ms         10       0.1029 ms          0.09512 ms
incr-par-filter-initial-cons  7.09166 ms         7.04395 ms         10       9.3801 ms          5.9058 ms
incr-seq-filter-initial-cons  8.3873 ms          7.9244 ms          10       10.7781 ms         6.8418 ms
current-incr-filter-init-cons 12.2898 ms         12.4255 ms         10       14.9829 ms         9.001970 ms
js-incr-filter-init-cons      14.9184 ms         15.1045 ms         10       16.8259 ms         13.5200 ms
## Change propagation
Name                            Avg                Median             Runs     Max time           Min time
incr-par-filter-change-prop     0.1406 ms          0.1411 ms          10       0.1721 ms          0.09298 ms
js-incr-filter-change-prop      0.1662 ms          0.1739 ms          10       0.2000 ms          0.07510 ms
incr-seq-filter-change-prop     0.2122 ms          0.2154 ms          10       0.2310 ms          0.1640 ms
current-incr-filter-change-prop 0.6264 ms          0.6549 ms          10       0.7119 ms          0.4680 ms
+ dune exec --release -- test/filter.exe -r 10 -n 100000 -c 1000 -d 6
# Filtering list of size: 100000 | 1000 elements changed in propagation | Domains spawned: 6
## Initial computation
Name                          Avg                Median             Runs     Max time           Min time
static-filter                 2.6517 ms          2.6329 ms          10       2.8018 ms          2.5601 ms
incr-par-filter-initial-cons  67.9008 ms         67.5469 ms         10       73.1818 ms         64.6178 ms
incr-seq-filter-initial-cons  81.2323 ms         81.9350 ms         10       91.09115 ms        69.04792 ms
current-incr-filter-init-cons 147.6945 ms        147.4289 ms        10       169.8648 ms        108.9251 ms
js-incr-filter-init-cons      160.08098 ms       156.7355 ms        10       188.6699 ms        152.007102 ms
## Change propagation
Name                            Avg                Median             Runs     Max time           Min time
incr-par-filter-change-prop     1.1547 ms          1.1729 ms          10       1.2269 ms          0.9989 ms
js-incr-filter-change-prop      2.2650 ms          2.2519 ms          10       2.7179 ms          1.9118 ms
incr-seq-filter-change-prop     3.03132 ms         3.04043 ms         10       3.2179 ms          2.5951 ms
current-incr-filter-change-prop 13.1239 ms         13.6198 ms         10       14.7159 ms         8.06999 ms


NUM_DOMAINS=8 RUNS=10 bash bench_runner.sh filter.exe 1000 100000 "i*10" 1
+ dune exec --release -- test/filter.exe -r 10 -n 1000 -c 10 -d 8
# Filtering list of size: 1000 | 10 elements changed in propagation | Domains spawned: 8
## Initial computation
Name                          Avg                Median             Runs     Max time           Min time
static-filter                 0.01502 ms         0.01204 ms         10       0.03004 ms         0.01001 ms
incr-seq-filter-initial-cons  0.3194 ms          0.2580 ms          10       0.5738 ms          0.2448 ms
current-incr-filter-init-cons 0.4921 ms          0.4868 ms          10       0.6148 ms          0.4107 ms
js-incr-filter-init-cons      0.5582 ms          0.5506 ms          10       0.7138 ms          0.4069 ms
incr-par-filter-initial-cons  0.6927 ms          0.3679 ms          10       2.2411 ms          0.3228 ms
## Change propagation
Name                            Avg                Median             Runs     Max time           Min time
js-incr-filter-change-prop      0.02105 ms         0.02133 ms         10       0.03290 ms         0.006914 ms
incr-seq-filter-change-prop     0.02355 ms         0.02408 ms         10       0.03314 ms         0.009059 ms
current-incr-filter-change-prop 0.05378 ms         0.05686 ms         10       0.06508 ms         0.01907 ms
incr-par-filter-change-prop     0.1716 ms          0.04839 ms         10       1.3060 ms          0.01692 ms
+ dune exec --release -- test/filter.exe -r 10 -n 10000 -c 100 -d 8
# Filtering list of size: 10000 | 100 elements changed in propagation | Domains spawned: 8
## Initial computation
Name                          Avg                Median             Runs     Max time           Min time
static-filter                 0.1064 ms          0.1065 ms          10       0.1208 ms          0.09703 ms
incr-par-filter-initial-cons  11.2697 ms         9.3514 ms          10       21.4941 ms         6.9038 ms
incr-seq-filter-initial-cons  13.7794 ms         10.5119 ms         10       23.5359 ms         8.4419 ms
current-incr-filter-init-cons 14.8310 ms         14.1965 ms         10       20.6580 ms         9.8860 ms
js-incr-filter-init-cons      15.6469 ms         15.2019 ms         10       18.2869 ms         14.5831 ms
## Change propagation
Name                            Avg                Median             Runs     Max time           Min time
js-incr-filter-change-prop      0.1763 ms          0.1875 ms          10       0.2050 ms          0.06318 ms
incr-seq-filter-change-prop     0.2263 ms          0.2365 ms          10       0.2450 ms          0.1459 ms
incr-par-filter-change-prop     0.5275 ms          0.1640 ms          10       2.3131 ms          0.1001 ms
current-incr-filter-change-prop 0.6578 ms          0.6555 ms          10       0.8940 ms          0.3740 ms
+ dune exec --release -- test/filter.exe -r 10 -n 100000 -c 1000 -d 8
# Filtering list of size: 100000 | 1000 elements changed in propagation | Domains spawned: 8
## Initial computation
Name                          Avg                Median             Runs     Max time           Min time
static-filter                 3.7908 ms          3.1166 ms          10       8.5790 ms          2.7520 ms
incr-seq-filter-initial-cons  104.1709 ms        97.5259 ms         10       154.7560 ms        91.7260 ms
js-incr-filter-init-cons      178.3752 ms        175.02701 ms       10       198.9870 ms        164.5741 ms
current-incr-filter-init-cons 183.3004 ms        172.6316 ms        10       279.7880 ms        156.9828 ms
incr-par-filter-initial-cons  189.3139 ms        185.7835 ms        10       291.2251 ms        124.7260 ms
## Change propagation
Name                            Avg                Median             Runs     Max time           Min time
incr-par-filter-change-prop     1.4256 ms          1.1811 ms          10       3.07679 ms         1.008987 ms
js-incr-filter-change-prop      2.5243 ms          2.5200 ms          10       2.9640 ms          1.9319 ms
incr-seq-filter-change-prop     3.06961 ms         3.06904 ms         10       3.6449 ms          2.5959 ms
current-incr-filter-change-prop 35.7146 ms         36.5095 ms         10       54.8360 ms         8.8250 ms


```

## merge_sort

```bash
NUM_DOMAINS=2 RUNS=10 bash bench_runner.sh merge_sort.exe 1000 100000 "i*10" 1
+ dune exec --release -- test/merge_sort.exe -r 10 -n 1000 -c 10 -d 2
# Sorting array of size: 1000 | 10 elements changed in propagation| Domains spawned: 2
## Initial computation
Name                            Avg                Median             Runs     Max time           Min time
static-seq-stdlib-sort          0.1614 ms          0.1440 ms          10       0.3008 ms          0.1199 ms
static-seq-custom-msort         0.1684 ms          0.1659 ms          10       0.1881 ms          0.1549 ms
incr-seq-msort-initial-cons     0.3771 ms          0.3525 ms          10       0.5860 ms          0.3330 ms
incr-par-msort-initial-cons     0.4416 ms          0.4305 ms          10       0.6761 ms          0.3111 ms
js-incr-msort-initial-cons      0.7382 ms          0.6594 ms          10       1.3220 ms          0.6020 ms
current-incr-msort-initial-cons 0.7541 ms          0.6079 ms          10       1.1808 ms          0.5049 ms
## Change propagation
Name                           Avg                Median             Runs     Max time           Min time
incr-par-msort-change-prop     0.06799 ms         0.06544 ms         10       0.09298 ms         0.05412 ms
incr-seq-msort-change-prop     0.09715 ms         0.09906 ms         10       0.1091 ms          0.08511 ms
js-incr-msort-change-prop      0.09951 ms         0.09906 ms         10       0.1149 ms          0.07891 ms
current-incr-msort-change-prop 0.1387 ms          0.1351 ms          10       0.2191 ms          0.1029 ms
## Append propagation
Name                           Avg                Median             Runs     Max time           Min time
incr-seq-msort-append-prop     0.04229 ms         0.04148 ms         10       0.05197 ms         0.03790 ms
js-incr-msort-append-prop      0.04229 ms         0.04100 ms         10       0.05006 ms         0.03600 ms
current-incr-msort-append-prop 0.04439 ms         0.04506 ms         10       0.04792 ms         0.03981 ms
incr-par-msort-append-prop     0.04725 ms         0.04649 ms         10       0.05793 ms         0.03814 ms
+ dune exec --release -- test/merge_sort.exe -r 10 -n 10000 -c 100 -d 2
# Sorting array of size: 10000 | 100 elements changed in propagation| Domains spawned: 2
## Initial computation
Name                            Avg                Median             Runs     Max time           Min time
static-seq-stdlib-sort          1.6531 ms          1.6280 ms          10       1.7671 ms          1.5850 ms
static-seq-custom-msort         2.7951 ms          2.7285 ms          10       3.7939 ms          2.5367 ms
incr-par-msort-initial-cons     9.4694 ms          9.06002 ms         10       11.5900 ms         7.9319 ms
incr-seq-msort-initial-cons     9.7261 ms          9.2819 ms          10       12.03298 ms        8.9790 ms
current-incr-msort-initial-cons 18.5557 ms         18.1823 ms         10       21.1029 ms         16.4849 ms
js-incr-msort-initial-cons      18.6921 ms         17.2075 ms         10       31.7111 ms         15.2590 ms
## Change propagation
Name                           Avg                Median             Runs     Max time           Min time
incr-par-msort-change-prop     0.8029 ms          0.8106 ms          10       0.8649 ms          0.7278 ms
incr-seq-msort-change-prop     1.7290 ms          1.6019 ms          10       2.7830 ms          1.5420 ms
js-incr-msort-change-prop      1.7641 ms          1.5864 ms          10       3.06916 ms         1.5299 ms
current-incr-msort-change-prop 3.2613 ms          3.3284 ms          10       3.5150 ms          2.6991 ms
## Append propagation
Name                           Avg                Median             Runs     Max time           Min time
incr-par-msort-append-prop     0.3497 ms          0.3409 ms          10       0.3769 ms          0.3268 ms
js-incr-msort-append-prop      0.3517 ms          0.3570 ms          10       0.3700 ms          0.3221 ms
incr-seq-msort-append-prop     0.3822 ms          0.3815 ms          10       0.4110 ms          0.3440 ms
current-incr-msort-append-prop 0.3834 ms          0.3805 ms          10       0.4200 ms          0.3609 ms
+ dune exec --release -- test/merge_sort.exe -r 10 -n 100000 -c 1000 -d 2
# Sorting array of size: 100000 | 1000 elements changed in propagation| Domains spawned: 2
## Initial computation
Name                            Avg                Median             Runs     Max time           Min time
static-seq-stdlib-sort          21.7539 ms         21.5419 ms         10       23.6170 ms         21.1610 ms
static-seq-custom-msort         79.3174 ms         73.8660 ms         10       97.3389 ms         73.03404 ms
incr-par-msort-initial-cons     96.2444 ms         90.4436 ms         10       127.2001 ms        87.8419 ms
incr-seq-msort-initial-cons     141.7153 ms        146.9559 ms        10       169.8939 ms        116.4979 ms
js-incr-msort-initial-cons      185.5528 ms        181.08201 ms       10       209.6760 ms        177.7200 ms
current-incr-msort-initial-cons 232.03303 ms       224.4579 ms        10       282.6020 ms        216.4220 ms
## Change propagation
Name                           Avg                Median             Runs     Max time           Min time
incr-par-msort-change-prop     19.3186 ms         19.4510 ms         10       23.07581 ms        17.3258 ms
js-incr-msort-change-prop      30.6046 ms         30.3590 ms         10       31.7900 ms         29.6890 ms
current-incr-msort-change-prop 39.2076 ms         39.8410 ms         10       41.5518 ms         34.1291 ms
incr-seq-msort-change-prop     40.5467 ms         40.1345 ms         10       45.1049 ms         38.6800 ms
## Append propagation
Name                           Avg                Median             Runs     Max time           Min time
js-incr-msort-append-prop      5.5949 ms          5.6345 ms          10       5.8391 ms          5.3179 ms
incr-par-msort-append-prop     5.9329 ms          5.9084 ms          10       6.3970 ms          5.5720 ms
current-incr-msort-append-prop 6.09972 ms         6.1570 ms          10       6.4811 ms          5.7129 ms
incr-seq-msort-append-prop     7.6396 ms          7.7195 ms          10       7.9529 ms          7.2460 ms


NUM_DOMAINS=4 RUNS=10 bash bench_runner.sh merge_sort.exe 1000 100000 "i*10" 1
+ dune exec --release -- test/merge_sort.exe -r 10 -n 1000 -c 10 -d 4
# Sorting array of size: 1000 | 10 elements changed in propagation| Domains spawned: 4
## Initial computation
Name                            Avg                Median             Runs     Max time           Min time
static-seq-stdlib-sort          0.09751 ms         0.09202 ms         10       0.1270 ms          0.08916 ms
static-seq-custom-msort         0.1263 ms          0.1235 ms          10       0.1358 ms          0.1201 ms
incr-par-msort-initial-cons     0.2289 ms          0.2170 ms          10       0.3371 ms          0.2028 ms
incr-seq-msort-initial-cons     0.2892 ms          0.2669 ms          10       0.4320 ms          0.2532 ms
current-incr-msort-initial-cons 0.4653 ms          0.4469 ms          10       0.6008 ms          0.4022 ms
js-incr-msort-initial-cons      0.5317 ms          0.5224 ms          10       0.6709 ms          0.4408 ms
## Change propagation
Name                           Avg                Median             Runs     Max time           Min time
incr-par-msort-change-prop     0.05538 ms         0.05507 ms         10       0.06389 ms         0.05006 ms
incr-seq-msort-change-prop     0.07483 ms         0.07295 ms         10       0.08606 ms         0.06794 ms
js-incr-msort-change-prop      0.07879 ms         0.08201 ms         10       0.09393 ms         0.06198 ms
current-incr-msort-change-prop 0.1090 ms          0.1094 ms          10       0.1258 ms          0.09703 ms
## Append propagation
Name                           Avg                Median             Runs     Max time           Min time
js-incr-msort-append-prop      0.03280 ms         0.03159 ms         10       0.04911 ms         0.02717 ms
incr-seq-msort-append-prop     0.03519 ms         0.03290 ms         10       0.05102 ms         0.03004 ms
current-incr-msort-append-prop 0.03747 ms         0.03600 ms         10       0.04792 ms         0.03290 ms
incr-par-msort-append-prop     0.04487 ms         0.04494 ms         10       0.06079 ms         0.03099 ms
+ dune exec --release -- test/merge_sort.exe -r 10 -n 10000 -c 100 -d 4
# Sorting array of size: 10000 | 100 elements changed in propagation| Domains spawned: 4
## Initial computation
Name                            Avg                Median             Runs     Max time           Min time
static-seq-stdlib-sort          1.2390 ms          1.2434 ms          10       1.3248 ms          1.1529 ms
static-seq-custom-msort         2.09872 ms         2.02059 ms         10       2.7770 ms          1.9619 ms
incr-par-msort-initial-cons     5.8629 ms          5.8809 ms          10       6.4840 ms          4.6708 ms
incr-seq-msort-initial-cons     7.2097 ms          6.9524 ms          10       8.4099 ms          6.7110 ms
current-incr-msort-initial-cons 13.6037 ms         13.2564 ms         10       15.9909 ms         9.4280 ms
js-incr-msort-initial-cons      14.3035 ms         14.09244 ms        10       15.9840 ms         13.7839 ms
## Change propagation
Name                           Avg                Median             Runs     Max time           Min time
incr-par-msort-change-prop     0.6235 ms          0.6049 ms          10       0.7112 ms          0.4951 ms
incr-seq-msort-change-prop     1.4123 ms          1.3470 ms          10       2.02298 ms         1.2838 ms
js-incr-msort-change-prop      1.4731 ms          1.3519 ms          10       2.6099 ms          1.2710 ms
current-incr-msort-change-prop 2.7328 ms          2.7624 ms          10       2.9249 ms          2.2990 ms
## Append propagation
Name                           Avg                Median             Runs     Max time           Min time
js-incr-msort-append-prop      0.2858 ms          0.2859 ms          10       0.3070 ms          0.2729 ms
incr-par-msort-append-prop     0.3058 ms          0.3025 ms          10       0.3290 ms          0.2820 ms
incr-seq-msort-append-prop     0.3072 ms          0.3060 ms          10       0.3371 ms          0.2801 ms
current-incr-msort-append-prop 0.3135 ms          0.3108 ms          10       0.3330 ms          0.2989 ms
+ dune exec --release -- test/merge_sort.exe -r 10 -n 100000 -c 1000 -d 4
# Sorting array of size: 100000 | 1000 elements changed in propagation| Domains spawned: 4
## Initial computation
Name                            Avg                Median             Runs     Max time           Min time
static-seq-stdlib-sort          17.8335 ms         17.7625 ms         10       18.9890 ms         17.4520 ms
static-seq-custom-msort         63.1023 ms         59.8555 ms         10       77.9428 ms         57.07907 ms
incr-par-msort-initial-cons     63.1095 ms         63.3665 ms         10       71.8488 ms         54.7208 ms
incr-seq-msort-initial-cons     103.8580 ms        102.7369 ms        10       126.1501 ms        85.2310 ms
js-incr-msort-initial-cons      160.5070 ms        154.5009 ms        10       179.9998 ms        153.3000 ms
current-incr-msort-initial-cons 164.4215 ms        163.4919 ms        10       183.4449 ms        135.5578 ms
## Change propagation
Name                           Avg                Median             Runs     Max time           Min time
incr-par-msort-change-prop     17.9423 ms         17.5114 ms         10       21.1191 ms         16.2630 ms
js-incr-msort-change-prop      30.5420 ms         30.3131 ms         10       32.3920 ms         28.8789 ms
incr-seq-msort-change-prop     32.5281 ms         32.6490 ms         10       34.1441 ms         31.02898 ms
current-incr-msort-change-prop 39.5019 ms         39.8154 ms         10       42.1109 ms         32.9589 ms
## Append propagation
Name                           Avg                Median             Runs     Max time           Min time
incr-par-msort-append-prop     6.4870 ms          6.4585 ms          10       6.6130 ms          6.3860 ms
js-incr-msort-append-prop      6.6700 ms          6.7105 ms          10       7.3299 ms          6.1881 ms
current-incr-msort-append-prop 7.2757 ms          7.3535 ms          10       8.5840 ms          6.5071 ms
incr-seq-msort-append-prop     7.8569 ms          7.8084 ms          10       8.5330 ms          7.2200 ms


NUM_DOMAINS=6 RUNS=10 bash bench_runner.sh merge_sort.exe 1000 100000 "i*10" 1
+ dune exec --release -- test/merge_sort.exe -r 10 -n 1000 -c 10 -d 6
# Sorting array of size: 1000 | 10 elements changed in propagation| Domains spawned: 6
## Initial computation
Name                            Avg                Median             Runs     Max time           Min time
static-seq-stdlib-sort          0.09486 ms         0.09346 ms         10       0.1039 ms          0.09107 ms
static-seq-custom-msort         0.1256 ms          0.1254 ms          10       0.1349 ms          0.1218 ms
incr-seq-msort-initial-cons     0.2887 ms          0.2734 ms          10       0.4460 ms          0.2570 ms
incr-par-msort-initial-cons     0.3067 ms          0.2251 ms          10       1.04188 ms         0.2169 ms
current-incr-msort-initial-cons 0.5143 ms          0.4824 ms          10       0.6561 ms          0.4210 ms
js-incr-msort-initial-cons      0.5593 ms          0.5544 ms          10       0.6458 ms          0.4298 ms
## Change propagation
Name                           Avg                Median             Runs     Max time           Min time
incr-par-msort-change-prop     0.07178 ms         0.07057 ms         10       0.08893 ms         0.06198 ms
incr-seq-msort-change-prop     0.08261 ms         0.07951 ms         10       0.09918 ms         0.06294 ms
js-incr-msort-change-prop      0.08592 ms         0.08606 ms         10       0.1060 ms          0.06794 ms
current-incr-msort-change-prop 0.1181 ms          0.1194 ms          10       0.1349 ms          0.08702 ms
## Append propagation
Name                           Avg                Median             Runs     Max time           Min time
js-incr-msort-append-prop      0.03483 ms         0.03409 ms         10       0.04100 ms         0.03290 ms
current-incr-msort-append-prop 0.04000 ms         0.03814 ms         10       0.04982 ms         0.03695 ms
incr-seq-msort-append-prop     0.04134 ms         0.03910 ms         10       0.05817 ms         0.03409 ms
incr-par-msort-append-prop     0.04353 ms         0.03802 ms         10       0.05984 ms         0.03504 ms
+ dune exec --release -- test/merge_sort.exe -r 10 -n 10000 -c 100 -d 6
# Sorting array of size: 10000 | 100 elements changed in propagation| Domains spawned: 6
## Initial computation
Name                            Avg                Median             Runs     Max time           Min time
static-seq-stdlib-sort          1.3159 ms          1.3035 ms          10       1.4231 ms          1.2478 ms
static-seq-custom-msort         2.2846 ms          2.2122 ms          10       2.9261 ms          2.05016 ms
incr-par-msort-initial-cons     5.3515 ms          5.3254 ms          10       6.1428 ms          4.8339 ms
incr-seq-msort-initial-cons     7.07783 ms         7.007598 ms        10       8.4259 ms          6.03008 ms
current-incr-msort-initial-cons 12.5879 ms         12.5635 ms         10       14.8899 ms         9.1099 ms
js-incr-msort-initial-cons      14.3256 ms         14.1700 ms         10       16.1750 ms         13.5240 ms
## Change propagation
Name                           Avg                Median             Runs     Max time           Min time
incr-par-msort-change-prop     0.6652 ms          0.6866 ms          10       0.7379 ms          0.5548 ms
incr-seq-msort-change-prop     1.4655 ms          1.4196 ms          10       1.9381 ms          1.3580 ms
js-incr-msort-change-prop      1.4671 ms          1.3644 ms          10       2.4960 ms          1.2590 ms
current-incr-msort-change-prop 2.8127 ms          2.8890 ms          10       3.01194 ms         2.1901 ms
## Append propagation
Name                           Avg                Median             Runs     Max time           Min time
js-incr-msort-append-prop      0.2948 ms          0.2920 ms          10       0.3149 ms          0.2820 ms
incr-seq-msort-append-prop     0.3164 ms          0.3194 ms          10       0.3340 ms          0.2858 ms
incr-par-msort-append-prop     0.3221 ms          0.3100 ms          10       0.4498 ms          0.2989 ms
current-incr-msort-append-prop 0.3383 ms          0.3389 ms          10       0.3640 ms          0.3180 ms
+ dune exec --release -- test/merge_sort.exe -r 10 -n 100000 -c 1000 -d 6
# Sorting array of size: 100000 | 1000 elements changed in propagation| Domains spawned: 6
## Initial computation
Name                            Avg                Median             Runs     Max time           Min time
static-seq-stdlib-sort          16.6263 ms         16.6090 ms         10       17.5640 ms         16.003131 ms
incr-par-msort-initial-cons     58.5623 ms         57.1804 ms         10       75.1512 ms         53.8840 ms
static-seq-custom-msort         68.1828 ms         62.4600 ms         10       82.3149 ms         58.8541 ms
incr-seq-msort-initial-cons     88.6409 ms         81.8325 ms         10       108.8728 ms        79.07295 ms
current-incr-msort-initial-cons 156.3312 ms        158.5474 ms        10       172.7118 ms        115.6570 ms
js-incr-msort-initial-cons      165.8655 ms        163.7134 ms        10       178.9050 ms        156.1980 ms
## Change propagation
Name                           Avg                Median             Runs     Max time           Min time
incr-par-msort-change-prop     18.8664 ms         18.6005 ms         10       21.4059 ms         16.5209 ms
incr-seq-msort-change-prop     33.5620 ms         33.4554 ms         10       34.6941 ms         32.3901 ms
js-incr-msort-change-prop      34.08846 ms        34.4070 ms         10       36.2880 ms         29.6018 ms
current-incr-msort-change-prop 43.7231 ms         43.7633 ms         10       54.6920 ms         32.5860 ms
## Append propagation
Name                           Avg                Median             Runs     Max time           Min time
incr-seq-msort-append-prop     7.9668 ms          7.9560 ms          10       8.4950 ms          7.4079 ms
incr-par-msort-append-prop     8.03287 ms         8.1195 ms          10       8.5282 ms          6.5479 ms
js-incr-msort-append-prop      8.1576 ms          8.2294 ms          10       8.3870 ms          7.8709 ms
current-incr-msort-append-prop 8.6598 ms          8.5600 ms          10       9.8891 ms          8.04400 ms


NUM_DOMAINS=8 RUNS=10 bash bench_runner.sh merge_sort.exe 1000 100000 "i*10" 1
+ dune exec --release -- test/merge_sort.exe -r 10 -n 1000 -c 10 -d 8
# Sorting array of size: 1000 | 10 elements changed in propagation| Domains spawned: 8
## Initial computation
Name                            Avg                Median             Runs     Max time           Min time
static-seq-stdlib-sort          0.1170 ms          0.1140 ms          10       0.1549 ms          0.1029 ms
static-seq-custom-msort         0.1521 ms          0.1503 ms          10       0.1649 ms          0.1430 ms
incr-seq-msort-initial-cons     0.3615 ms          0.3429 ms          10       0.5400 ms          0.3309 ms
current-incr-msort-initial-cons 0.5375 ms          0.5145 ms          10       0.6759 ms          0.4601 ms
js-incr-msort-initial-cons      0.5766 ms          0.5794 ms          10       0.6520 ms          0.4789 ms
incr-par-msort-initial-cons     1.7266 ms          0.9489 ms          10       4.09483 ms         0.2629 ms
## Change propagation
Name                           Avg                Median             Runs     Max time           Min time
js-incr-msort-change-prop      0.09732 ms         0.09155 ms         10       0.1530 ms          0.06794 ms
current-incr-msort-change-prop 0.1206 ms          0.1155 ms          10       0.1490 ms          0.09298 ms
incr-seq-msort-change-prop     0.1664 ms          0.08547 ms         10       0.8850 ms          0.06198 ms
incr-par-msort-change-prop     1.08699 ms         1.5240 ms          10       1.9099 ms          0.06103 ms
## Append propagation
Name                           Avg                Median             Runs     Max time           Min time
current-incr-msort-append-prop 0.03964 ms         0.03957 ms         10       0.04291 ms         0.03600 ms
incr-par-msort-append-prop     0.04053 ms         0.04005 ms         10       0.04696 ms         0.03600 ms
js-incr-msort-append-prop      0.04439 ms         0.03647 ms         10       0.1201 ms          0.03194 ms
incr-seq-msort-append-prop     0.04501 ms         0.04363 ms         10       0.05316 ms         0.03886 ms
+ dune exec --release -- test/merge_sort.exe -r 10 -n 10000 -c 100 -d 8
# Sorting array of size: 10000 | 100 elements changed in propagation| Domains spawned: 8
## Initial computation
Name                            Avg                Median             Runs     Max time           Min time
static-seq-stdlib-sort          1.4378 ms          1.4275 ms          10       1.6181 ms          1.2521 ms
static-seq-custom-msort         2.6222 ms          2.5169 ms          10       3.2610 ms          2.4640 ms
incr-par-msort-initial-cons     9.7701 ms          6.6440 ms          10       21.2690 ms         5.3169 ms
incr-seq-msort-initial-cons     10.3125 ms         8.09597 ms         10       24.7209 ms         7.8580 ms
current-incr-msort-initial-cons 13.7715 ms         13.6485 ms         10       16.5388 ms         11.6388 ms
js-incr-msort-initial-cons      15.7336 ms         15.3160 ms         10       17.6930 ms         14.5511 ms
## Change propagation
Name                           Avg                Median             Runs     Max time           Min time
incr-par-msort-change-prop     1.2380 ms          0.7073 ms          10       2.9888 ms          0.5991 ms
incr-seq-msort-change-prop     1.4492 ms          1.4021 ms          10       1.8470 ms          1.3339 ms
js-incr-msort-change-prop      1.5203 ms          1.3535 ms          10       2.9940 ms          1.3110 ms
current-incr-msort-change-prop 6.3951 ms          6.6109 ms          10       8.5000 ms          2.4209 ms
## Append propagation
Name                           Avg                Median             Runs     Max time           Min time
js-incr-msort-append-prop      0.2948 ms          0.2930 ms          10       0.3321 ms          0.2720 ms
incr-par-msort-append-prop     0.3086 ms          0.3085 ms          10       0.3218 ms          0.2901 ms
incr-seq-msort-append-prop     0.3193 ms          0.3194 ms          10       0.3368 ms          0.3058 ms
current-incr-msort-append-prop 0.3412 ms          0.3415 ms          10       0.3859 ms          0.3108 ms
+ dune exec --release -- test/merge_sort.exe -r 10 -n 100000 -c 1000 -d 8
# Sorting array of size: 100000 | 1000 elements changed in propagation| Domains spawned: 8
## Initial computation
Name                            Avg                Median             Runs     Max time           Min time
static-seq-stdlib-sort          18.5540 ms         18.8850 ms         10       19.2928 ms         17.2271 ms
static-seq-custom-msort         71.1806 ms         69.9360 ms         10       88.2670 ms         62.7779 ms
incr-seq-msort-initial-cons     111.7742 ms        115.1790 ms        10       125.4420 ms        94.1121 ms
current-incr-msort-initial-cons 173.1522 ms        176.1109 ms        10       195.7218 ms        123.1517 ms
js-incr-msort-initial-cons      181.1812 ms        179.1725 ms        10       199.6638 ms        172.3380 ms
incr-par-msort-initial-cons     201.8296 ms        202.9554 ms        10       256.3738 ms        115.7040 ms
## Change propagation
Name                           Avg                Median             Runs     Max time           Min time
incr-par-msort-change-prop     47.9430 ms         51.01656 ms        10       56.4191 ms         18.8519 ms
js-incr-msort-change-prop      56.3240 ms         56.7810 ms         10       63.07101 ms        46.1518 ms
incr-seq-msort-change-prop     58.9397 ms         62.7890 ms         10       64.7969 ms         31.3849 ms
current-incr-msort-change-prop 66.7418 ms         68.9315 ms         10       78.06181 ms        36.7410 ms
## Append propagation
Name                           Avg                Median             Runs     Max time           Min time
js-incr-msort-append-prop      25.4574 ms         26.04293 ms        10       29.1600 ms         20.4899 ms
incr-par-msort-append-prop     27.2209 ms         27.1425 ms         10       31.008958 ms       22.3228 ms
incr-seq-msort-append-prop     28.4009 ms         29.2426 ms         10       30.7919 ms         23.7810 ms
current-incr-msort-append-prop 28.4165 ms         29.02007 ms        10       31.6181 ms         23.2541 ms


```

## rabin_karp

```bash
NUM_DOMAINS=2 RUNS=10 bash bench_runner.sh rabin_karp.exe 10000 100000 "i*10" 1
+ dune exec --release -- test/rabin_karp.exe -r 10 -n 10000 -c 100 -d 2
# Rabin Karp Hash | No. of chunks: 10000, Chunk size = 64, Changes during propagation:100 | Domains spawned: 2
## Initial computation
Name                         Avg                Median             Runs     Max time           Min time
static-par-rk                3.8561 ms          3.7630 ms          10       4.8868 ms          3.6301 ms
incr-par-rk-initial-cons     8.6934 ms          8.6904 ms          10       8.9209 ms          8.4431 ms
incr-seq-rk-initial-cons     15.08502 ms        15.9004 ms         10       16.7009 ms         13.07010 ms
js-incr-rk-initial-cons      18.1740 ms         17.8406 ms         10       20.6968 ms         17.5199 ms
current-incr-rk-initial-cons 21.2623 ms         21.2695 ms         10       23.8120 ms         18.7039 ms
## Change propagation
Name                 Avg                Median             Runs     Max time           Min time
incr-par-rk-prop     0.1561 ms          0.1571 ms          10       0.1738 ms          0.1251 ms
js-incr-rk-prop      0.2410 ms          0.2484 ms          10       0.2689 ms          0.1380 ms
incr-seq-rk-prop     0.2866 ms          0.2839 ms          10       0.3449 ms          0.2448 ms
current-incr-rk-prop 0.7439 ms          0.7704 ms          10       0.8490 ms          0.5450 ms
+ dune exec --release -- test/rabin_karp.exe -r 10 -n 100000 -c 1000 -d 2
# Rabin Karp Hash | No. of chunks: 100000, Chunk size = 64, Changes during propagation:1000 | Domains spawned: 2
## Initial computation
Name                         Avg                Median             Runs     Max time           Min time
static-par-rk                38.3393 ms         37.3049 ms         10       43.07985 ms        35.8631 ms
incr-par-rk-initial-cons     87.9293 ms         86.5770 ms         10       96.4510 ms         83.3821 ms
incr-seq-rk-initial-cons     145.8378 ms        144.3779 ms        10       162.4829 ms        128.3361 ms
js-incr-rk-initial-cons      204.7333 ms        200.9290 ms        10       225.1479 ms        199.5649 ms
current-incr-rk-initial-cons 241.8613 ms        239.03012 ms       10       278.01990 ms       189.9929 ms
## Change propagation
Name                 Avg                Median             Runs     Max time           Min time
incr-par-rk-prop     1.6926 ms          1.7215 ms          10       1.7571 ms          1.5408 ms
js-incr-rk-prop      2.9486 ms          3.02100 ms         10       3.1118 ms          2.4130 ms
incr-seq-rk-prop     3.9322 ms          3.8659 ms          10       4.7600 ms          3.6809 ms
current-incr-rk-prop 15.1693 ms         16.08908 ms        10       16.9250 ms         9.1822 ms


NUM_DOMAINS=4 RUNS=10 bash bench_runner.sh rabin_karp.exe 10000 100000 "i*10" 1
+ dune exec --release -- test/rabin_karp.exe -r 10 -n 10000 -c 100 -d 4
# Rabin Karp Hash | No. of chunks: 10000, Chunk size = 64, Changes during propagation:100 | Domains spawned: 4
## Initial computation
Name                         Avg                Median             Runs     Max time           Min time
static-par-rk                2.8027 ms          2.6654 ms          10       3.6871 ms          2.6309 ms
incr-par-rk-initial-cons     6.1934 ms          5.8095 ms          10       7.4281 ms          5.6700 ms
incr-seq-rk-initial-cons     13.4851 ms         13.1975 ms         10       14.7550 ms         12.7248 ms
js-incr-rk-initial-cons      18.2703 ms         17.8670 ms         10       20.4408 ms         17.7810 ms
current-incr-rk-initial-cons 19.6823 ms         19.9810 ms         10       22.3238 ms         15.8090 ms
## Change propagation
Name                 Avg                Median             Runs     Max time           Min time
incr-par-rk-prop     0.1322 ms          0.1349 ms          10       0.1440 ms          0.09417 ms
js-incr-rk-prop      0.2464 ms          0.2574 ms          10       0.2849 ms          0.1389 ms
incr-seq-rk-prop     0.2849 ms          0.2900 ms          10       0.3068 ms          0.2410 ms
current-incr-rk-prop 0.7515 ms          0.7333 ms          10       0.9758 ms          0.5879 ms
+ dune exec --release -- test/rabin_karp.exe -r 10 -n 100000 -c 1000 -d 4
# Rabin Karp Hash | No. of chunks: 100000, Chunk size = 64, Changes during propagation:1000 | Domains spawned: 4
## Initial computation
Name                         Avg                Median             Runs     Max time           Min time
static-par-rk                26.9544 ms         26.7745 ms         10       29.7920 ms         26.1499 ms
incr-par-rk-initial-cons     62.3718 ms         61.4035 ms         10       68.4621 ms         59.4241 ms
incr-seq-rk-initial-cons     135.6207 ms        132.1430 ms        10       149.1539 ms        127.5238 ms
js-incr-rk-initial-cons      206.7576 ms        203.4555 ms        10       225.7959 ms        200.5178 ms
current-incr-rk-initial-cons 217.2071 ms        214.8865 ms        10       242.7890 ms        171.9257 ms
## Change propagation
Name                 Avg                Median             Runs     Max time           Min time
incr-par-rk-prop     1.3436 ms          1.3309 ms          10       1.5389 ms          1.2328 ms
js-incr-rk-prop      2.9943 ms          3.02195 ms         10       3.08299 ms         2.6800 ms
incr-seq-rk-prop     3.9778 ms          3.8855 ms          10       5.08904 ms         3.5989 ms
current-incr-rk-prop 14.7217 ms         15.3344 ms         10       16.6239 ms         9.1488 ms


NUM_DOMAINS=6 RUNS=10 bash bench_runner.sh rabin_karp.exe 10000 100000 "i*10" 1
+ dune exec --release -- test/rabin_karp.exe -r 10 -n 10000 -c 100 -d 6
# Rabin Karp Hash | No. of chunks: 10000, Chunk size = 64, Changes during propagation:100 | Domains spawned: 6
## Initial computation
Name                         Avg                Median             Runs     Max time           Min time
static-par-rk                2.3484 ms          2.2730 ms          10       2.8781 ms          2.2070 ms
incr-par-rk-initial-cons     5.9740 ms          5.8480 ms          10       7.3018 ms          5.5310 ms
incr-seq-rk-initial-cons     12.9154 ms         12.7528 ms         10       13.5951 ms         12.5992 ms
current-incr-rk-initial-cons 18.7864 ms         18.8175 ms         10       20.9319 ms         15.6280 ms
js-incr-rk-initial-cons      18.9589 ms         18.6434 ms         10       20.6389 ms         18.2428 ms
## Change propagation
Name                 Avg                Median             Runs     Max time           Min time
incr-par-rk-prop     0.1286 ms          0.1305 ms          10       0.1440 ms          0.09799 ms
js-incr-rk-prop      0.2485 ms          0.2609 ms          10       0.2720 ms          0.1480 ms
incr-seq-rk-prop     0.3651 ms          0.3725 ms          10       0.4069 ms          0.2319 ms
current-incr-rk-prop 0.8188 ms          0.8095 ms          10       1.1508 ms          0.6060 ms
+ dune exec --release -- test/rabin_karp.exe -r 10 -n 100000 -c 1000 -d 6
# Rabin Karp Hash | No. of chunks: 100000, Chunk size = 64, Changes during propagation:1000 | Domains spawned: 6
## Initial computation
Name                         Avg                Median             Runs     Max time           Min time
static-par-rk                22.02599 ms        21.9991 ms         10       22.6058 ms         21.5990 ms
incr-par-rk-initial-cons     58.5500 ms         56.2371 ms         10       69.1578 ms         54.6710 ms
incr-seq-rk-initial-cons     138.8288 ms        141.8039 ms        10       156.8100 ms        123.9910 ms
js-incr-rk-initial-cons      212.9465 ms        210.4710 ms        10       233.7779 ms        202.8350 ms
current-incr-rk-initial-cons 213.1254 ms        212.7320 ms        10       237.01810 ms       174.5421 ms
## Change propagation
Name                 Avg                Median             Runs     Max time           Min time
incr-par-rk-prop     1.4761 ms          1.2719 ms          10       3.4658 ms          1.1818 ms
js-incr-rk-prop      2.9712 ms          3.003001 ms        10       3.1468 ms          2.5100 ms
incr-seq-rk-prop     3.9334 ms          3.9255 ms          10       4.6260 ms          3.6249 ms
current-incr-rk-prop 21.6415 ms         22.08852 ms        10       28.9559 ms         9.1221 ms


NUM_DOMAINS=8 RUNS=10 bash bench_runner.sh rabin_karp.exe 10000 100000 "i*10" 1
+ dune exec --release -- test/rabin_karp.exe -r 10 -n 10000 -c 100 -d 8
# Rabin Karp Hash | No. of chunks: 10000, Chunk size = 64, Changes during propagation:100 | Domains spawned: 8
## Initial computation
Name                         Avg                Median             Runs     Max time           Min time
static-par-rk                3.1570 ms          2.3124 ms          10       6.03985 ms         2.07018 ms
incr-par-rk-initial-cons     7.5839 ms          7.1330 ms          10       12.7079 ms         5.4788 ms
incr-seq-rk-initial-cons     15.7287 ms         13.6950 ms         10       31.6689 ms         12.9990 ms
js-incr-rk-initial-cons      20.5443 ms         19.8389 ms         10       24.6818 ms         19.6909 ms
current-incr-rk-initial-cons 20.8081 ms         19.4935 ms         10       29.3281 ms         18.4531 ms
## Change propagation
Name                 Avg                Median             Runs     Max time           Min time
js-incr-rk-prop      0.2787 ms          0.2703 ms          10       0.4110 ms          0.1409 ms
incr-seq-rk-prop     0.3263 ms          0.3329 ms          10       0.4010 ms          0.2241 ms
current-incr-rk-prop 0.8282 ms          0.8366 ms          10       1.1429 ms          0.5288 ms
incr-par-rk-prop     1.9118 ms          1.8284 ms          10       5.2340 ms          0.1130 ms
+ dune exec --release -- test/rabin_karp.exe -r 10 -n 100000 -c 1000 -d 8
# Rabin Karp Hash | No. of chunks: 100000, Chunk size = 64, Changes during propagation:1000 | Domains spawned: 8
## Initial computation
Name                         Avg                Median             Runs     Max time           Min time
static-par-rk                50.09145 ms        49.01313 ms        10       62.8750 ms         40.7850 ms
incr-seq-rk-initial-cons     156.8182 ms        151.7804 ms        10       206.5598 ms        129.5840 ms
incr-par-rk-initial-cons     180.7567 ms        177.9395 ms        10       217.1218 ms        137.8259 ms
js-incr-rk-initial-cons      228.1600 ms        230.2294 ms        10       246.03605 ms       216.6550 ms
current-incr-rk-initial-cons 276.09741 ms       281.3265 ms        10       336.09604 ms       172.8429 ms
## Change propagation
Name                 Avg                Median             Runs     Max time           Min time
incr-par-rk-prop     1.4198 ms          1.2129 ms          10       3.4849 ms          1.1229 ms
js-incr-rk-prop      2.9608 ms          3.003478 ms        10       3.07893 ms         2.5479 ms
incr-seq-rk-prop     4.03342 ms         3.9434 ms          10       4.8959 ms          3.6380 ms
current-incr-rk-prop 31.3278 ms         33.6215 ms         10       37.5990 ms         9.3650 ms


```

## sum_array

```bash
NUM_DOMAINS=2 RUNS=10 bash bench_runner.sh sum_array.exe 1000 100000 "i*10" 1
+ dune exec --release -- test/sum_array.exe -r 10 -n 1000 -c 10 -d 2
# Sum of int array of size: 1000 | 10 elements changed in propagation benchmarks | Domains spawned: 2
## Initial computation
Name                              Avg                Median             Runs     Max time           Min time
static-seq-arr-sum                0.002264 ms        0.001907 ms        10       0.003099 ms        0.001907 ms
incr-par-arr-sum-initial-cons     0.07839 ms         0.07092 ms         10       0.1261 ms          0.06198 ms
incr-seq-arr-sum-initial-cons     0.1364 ms          0.1325 ms          10       0.1590 ms          0.1270 ms
current-incr-arr-sum-initial-cons 0.2450 ms          0.2385 ms          10       0.3149 ms          0.2090 ms
js-incr-arr-sum-initial-cons      0.2525 ms          0.2459 ms          10       0.3249 ms          0.2250 ms
## Change propagation
Name                      Avg                Median             Runs     Max time           Min time
js_incr-arr-sum-prop      0.01032 ms         0.009536 ms        10       0.01597 ms         0.005006 ms
incr-seq-arr-sum-prop     0.01246 ms         0.01215 ms         10       0.02002 ms         0.007867 ms
incr-par-arr-sum-prop     0.01525 ms         0.01549 ms         10       0.01788 ms         0.01215 ms
current-incr-arr-sum-prop 0.03304 ms         0.03349 ms         10       0.03910 ms         0.01883 ms
+ dune exec --release -- test/sum_array.exe -r 10 -n 10000 -c 100 -d 2
# Sum of int array of size: 10000 | 100 elements changed in propagation benchmarks | Domains spawned: 2
## Initial computation
Name                              Avg                Median             Runs     Max time           Min time
static-seq-arr-sum                0.02057 ms         0.02002 ms         10       0.02288 ms         0.01883 ms
incr-par-arr-sum-initial-cons     3.4806 ms          3.6325 ms          10       4.1830 ms          2.7630 ms
incr-seq-arr-sum-initial-cons     4.8333 ms          5.2204 ms          10       5.9809 ms          3.7579 ms
js-incr-arr-sum-initial-cons      5.9167 ms          5.4879 ms          10       8.3241 ms          5.3858 ms
current-incr-arr-sum-initial-cons 7.9298 ms          7.8930 ms          10       9.4699 ms          5.7671 ms
## Change propagation
Name                      Avg                Median             Runs     Max time           Min time
incr-par-arr-sum-prop     0.1169 ms          0.1150 ms          10       0.1430 ms          0.09799 ms
js_incr-arr-sum-prop      0.1185 ms          0.1214 ms          10       0.1349 ms          0.06604 ms
incr-seq-arr-sum-prop     0.1835 ms          0.1904 ms          10       0.2009 ms          0.1308 ms
current-incr-arr-sum-prop 0.6543 ms          0.6260 ms          10       1.1711 ms          0.4789 ms
+ dune exec --release -- test/sum_array.exe -r 10 -n 100000 -c 1000 -d 2
# Sum of int array of size: 100000 | 1000 elements changed in propagation benchmarks | Domains spawned: 2
## Initial computation
Name                              Avg                Median             Runs     Max time           Min time
static-seq-arr-sum                0.2186 ms          0.2039 ms          10       0.2720 ms          0.1978 ms
incr-par-arr-sum-initial-cons     39.2238 ms         39.0625 ms         10       41.3269 ms         37.2080 ms
incr-seq-arr-sum-initial-cons     44.2090 ms         37.1758 ms         10       59.7610 ms         36.1139 ms
js-incr-arr-sum-initial-cons      79.4338 ms         76.9265 ms         10       95.8390 ms         74.8178 ms
current-incr-arr-sum-initial-cons 102.6795 ms        99.6925 ms         10       121.07801 ms       93.09101 ms
## Change propagation
Name                      Avg                Median             Runs     Max time           Min time
incr-par-arr-sum-prop     1.2061 ms          1.2065 ms          10       1.2831 ms          1.1219 ms
js_incr-arr-sum-prop      1.5514 ms          1.5770 ms          10       1.6229 ms          1.2540 ms
incr-seq-arr-sum-prop     2.4181 ms          2.4299 ms          10       2.5391 ms          2.2058 ms
current-incr-arr-sum-prop 11.6821 ms         12.1433 ms         10       13.01097 ms        7.7769 ms


NUM_DOMAINS=4 RUNS=10 bash bench_runner.sh sum_array.exe 1000 100000 "i*10" 1
+ dune exec --release -- test/sum_array.exe -r 10 -n 1000 -c 10 -d 4
# Sum of int array of size: 1000 | 10 elements changed in propagation benchmarks | Domains spawned: 4
## Initial computation
Name                              Avg                Median             Runs     Max time           Min time
static-seq-arr-sum                0.002861 ms        0.002503 ms        10       0.004053 ms        0.001907 ms
incr-par-arr-sum-initial-cons     0.07064 ms         0.06103 ms         10       0.1351 ms          0.04506 ms
incr-seq-arr-sum-initial-cons     0.1433 ms          0.1410 ms          10       0.1571 ms          0.1351 ms
js-incr-arr-sum-initial-cons      0.2629 ms          0.2579 ms          10       0.3139 ms          0.2400 ms
current-incr-arr-sum-initial-cons 0.2732 ms          0.2639 ms          10       0.3359 ms          0.2219 ms
## Change propagation
Name                      Avg                Median             Runs     Max time           Min time
incr-seq-arr-sum-prop     0.01206 ms         0.01251 ms         10       0.01502 ms         0.008821 ms
js_incr-arr-sum-prop      0.01280 ms         0.01204 ms         10       0.02193 ms         0.006914 ms
incr-par-arr-sum-prop     0.01623 ms         0.01645 ms         10       0.02098 ms         0.01001 ms
current-incr-arr-sum-prop 0.04253 ms         0.03957 ms         10       0.07700 ms         0.01907 ms
+ dune exec --release -- test/sum_array.exe -r 10 -n 10000 -c 100 -d 4
# Sum of int array of size: 10000 | 100 elements changed in propagation benchmarks | Domains spawned: 4
## Initial computation
Name                              Avg                Median             Runs     Max time           Min time
static-seq-arr-sum                0.02260 ms         0.02050 ms         10       0.04005 ms         0.02002 ms
incr-par-arr-sum-initial-cons     2.2440 ms          2.1010 ms          10       3.2188 ms          1.9648 ms
incr-seq-arr-sum-initial-cons     3.9117 ms          3.7565 ms          10       4.7497 ms          3.2761 ms
js-incr-arr-sum-initial-cons      6.3712 ms          6.1194 ms          10       8.1760 ms          5.9540 ms
current-incr-arr-sum-initial-cons 6.8267 ms          7.1489 ms          10       8.04209 ms         5.03897 ms
## Change propagation
Name                      Avg                Median             Runs     Max time           Min time
incr-par-arr-sum-prop     0.1033 ms          0.1063 ms          10       0.1189 ms          0.06604 ms
js_incr-arr-sum-prop      0.1229 ms          0.1275 ms          10       0.1378 ms          0.06413 ms
incr-seq-arr-sum-prop     0.1831 ms          0.1826 ms          10       0.2398 ms          0.1459 ms
current-incr-arr-sum-prop 0.6873 ms          0.6414 ms          10       1.1548 ms          0.5090 ms
+ dune exec --release -- test/sum_array.exe -r 10 -n 100000 -c 1000 -d 4
# Sum of int array of size: 100000 | 1000 elements changed in propagation benchmarks | Domains spawned: 4
## Initial computation
Name                              Avg                Median             Runs     Max time           Min time
static-seq-arr-sum                0.2050 ms          0.2050 ms          10       0.2110 ms          0.1978 ms
incr-par-arr-sum-initial-cons     25.03008 ms        24.9054 ms         10       27.6861 ms         22.7530 ms
incr-seq-arr-sum-initial-cons     44.6033 ms         43.9624 ms         10       56.03790 ms        35.3760 ms
js-incr-arr-sum-initial-cons      83.6524 ms         81.6305 ms         10       104.6590 ms        75.7679 ms
current-incr-arr-sum-initial-cons 91.8003 ms         88.9350 ms         10       108.2301 ms        80.8339 ms
## Change propagation
Name                      Avg                Median             Runs     Max time           Min time
incr-par-arr-sum-prop     0.9636 ms          0.9590 ms          10       1.02996 ms         0.9069 ms
js_incr-arr-sum-prop      1.5501 ms          1.5723 ms          10       1.6870 ms          1.2781 ms
incr-seq-arr-sum-prop     2.4145 ms          2.4240 ms          10       2.5172 ms          2.2327 ms
current-incr-arr-sum-prop 12.07783 ms        12.6404 ms         10       13.6680 ms         7.7610 ms


NUM_DOMAINS=6 RUNS=10 bash bench_runner.sh sum_array.exe 1000 100000 "i*10" 1
+ dune exec --release -- test/sum_array.exe -r 10 -n 1000 -c 10 -d 6
# Sum of int array of size: 1000 | 10 elements changed in propagation benchmarks | Domains spawned: 6
## Initial computation
Name                              Avg                Median             Runs     Max time           Min time
static-seq-arr-sum                0.003385 ms        0.003933 ms        10       0.005006 ms        0.001907 ms
incr-par-arr-sum-initial-cons     0.07629 ms         0.06294 ms         10       0.1459 ms          0.05602 ms
incr-seq-arr-sum-initial-cons     0.1705 ms          0.1535 ms          10       0.3480 ms          0.1342 ms
current-incr-arr-sum-initial-cons 0.2990 ms          0.3010 ms          10       0.3790 ms          0.2188 ms
js-incr-arr-sum-initial-cons      0.3122 ms          0.2715 ms          10       0.6680 ms          0.2381 ms
## Change propagation
Name                      Avg                Median             Runs     Max time           Min time
incr-seq-arr-sum-prop     0.01242 ms         0.01251 ms         10       0.01502 ms         0.009059 ms
js_incr-arr-sum-prop      0.01468 ms         0.01406 ms         10       0.02503 ms         0.006914 ms
incr-par-arr-sum-prop     0.01895 ms         0.01788 ms         10       0.02408 ms         0.01597 ms
current-incr-arr-sum-prop 0.03802 ms         0.03910 ms         10       0.04506 ms         0.02312 ms
+ dune exec --release -- test/sum_array.exe -r 10 -n 10000 -c 100 -d 6
# Sum of int array of size: 10000 | 100 elements changed in propagation benchmarks | Domains spawned: 6
## Initial computation
Name                              Avg                Median             Runs     Max time           Min time
static-seq-arr-sum                0.02303 ms         0.02002 ms         10       0.04291 ms         0.01907 ms
incr-par-arr-sum-initial-cons     2.2838 ms          2.3134 ms          10       3.1988 ms          1.06787 ms
incr-seq-arr-sum-initial-cons     3.4759 ms          3.3620 ms          10       4.3101 ms          3.3049 ms
current-incr-arr-sum-initial-cons 6.4071 ms          6.4084 ms          10       7.2789 ms          4.7738 ms
js-incr-arr-sum-initial-cons      6.4688 ms          6.2680 ms          10       8.1391 ms          6.1309 ms
## Change propagation
Name                      Avg                Median             Runs     Max time           Min time
incr-par-arr-sum-prop     0.1036 ms          0.1044 ms          10       0.1230 ms          0.06413 ms
js_incr-arr-sum-prop      0.1280 ms          0.1330 ms          10       0.1568 ms          0.05817 ms
incr-seq-arr-sum-prop     0.2263 ms          0.1844 ms          10       0.6229 ms          0.1568 ms
current-incr-arr-sum-prop 0.6487 ms          0.6200 ms          10       0.9899 ms          0.5118 ms
+ dune exec --release -- test/sum_array.exe -r 10 -n 100000 -c 1000 -d 6
# Sum of int array of size: 100000 | 1000 elements changed in propagation benchmarks | Domains spawned: 6
## Initial computation
Name                              Avg                Median             Runs     Max time           Min time
static-seq-arr-sum                0.2289 ms          0.2081 ms          10       0.4138 ms          0.2000 ms
incr-par-arr-sum-initial-cons     24.4725 ms         23.1685 ms         10       31.3708 ms         20.9999 ms
incr-seq-arr-sum-initial-cons     38.2335 ms         35.5249 ms         10       47.8651 ms         32.08589 ms
js-incr-arr-sum-initial-cons      85.02244 ms        82.7144 ms         10       101.2079 ms        79.5531 ms
current-incr-arr-sum-initial-cons 85.7543 ms         83.4673 ms         10       99.9159 ms         76.9250 ms
## Change propagation
Name                      Avg                Median             Runs     Max time           Min time
incr-par-arr-sum-prop     0.8947 ms          0.8840 ms          10       0.9901 ms          0.8399 ms
js_incr-arr-sum-prop      1.5575 ms          1.5970 ms          10       1.6241 ms          1.2481 ms
incr-seq-arr-sum-prop     2.3832 ms          2.3939 ms          10       2.4719 ms          2.1491 ms
current-incr-arr-sum-prop 12.2551 ms         12.2874 ms         10       14.3568 ms         10.8580 ms


NUM_DOMAINS=8 RUNS=10 bash bench_runner.sh sum_array.exe 1000 100000 "i*10" 1
+ dune exec --release -- test/sum_array.exe -r 10 -n 1000 -c 10 -d 8
# Sum of int array of size: 1000 | 10 elements changed in propagation benchmarks | Domains spawned: 8
## Initial computation
Name                              Avg                Median             Runs     Max time           Min time
static-seq-arr-sum                0.002932 ms        0.002861 ms        10       0.005006 ms        0.001907 ms
incr-seq-arr-sum-initial-cons     0.1886 ms          0.1718 ms          10       0.3600 ms          0.1571 ms
current-incr-arr-sum-initial-cons 0.2831 ms          0.2695 ms          10       0.3850 ms          0.2260 ms
js-incr-arr-sum-initial-cons      0.3046 ms          0.2709 ms          10       0.4889 ms          0.2539 ms
incr-par-arr-sum-initial-cons     0.9238 ms          0.1094 ms          10       3.05795 ms         0.08201 ms
## Change propagation
Name                      Avg                Median             Runs     Max time           Min time
js_incr-arr-sum-prop      0.01127 ms         0.01108 ms         10       0.01883 ms         0.005960 ms
incr-seq-arr-sum-prop     0.01692 ms         0.01645 ms         10       0.02217 ms         0.008106 ms
current-incr-arr-sum-prop 0.04317 ms         0.04386 ms         10       0.05888 ms         0.01883 ms
incr-par-arr-sum-prop     0.2893 ms          0.03612 ms         10       2.5899 ms          0.01192 ms
+ dune exec --release -- test/sum_array.exe -r 10 -n 10000 -c 100 -d 8
# Sum of int array of size: 10000 | 100 elements changed in propagation benchmarks | Domains spawned: 8
## Initial computation
Name                              Avg                Median             Runs     Max time           Min time
static-seq-arr-sum                0.02238 ms         0.02157 ms         10       0.02598 ms         0.01978 ms
incr-par-arr-sum-initial-cons     2.5541 ms          1.9685 ms          10       4.9841 ms          0.9360 ms
incr-seq-arr-sum-initial-cons     4.7961 ms          4.4360 ms          10       6.1450 ms          4.01496 ms
current-incr-arr-sum-initial-cons 7.3287 ms          7.1918 ms          10       8.3940 ms          6.3841 ms
js-incr-arr-sum-initial-cons      7.4409 ms          7.1314 ms          10       9.5329 ms          6.5770 ms
## Change propagation
Name                      Avg                Median             Runs     Max time           Min time
js_incr-arr-sum-prop      0.1348 ms          0.1424 ms          10       0.1599 ms          0.05888 ms
incr-seq-arr-sum-prop     0.1962 ms          0.1986 ms          10       0.2179 ms          0.1640 ms
current-incr-arr-sum-prop 0.6739 ms          0.6616 ms          10       1.003980 ms        0.5137 ms
incr-par-arr-sum-prop     1.5491 ms          0.7684 ms          10       4.4310 ms          0.07581 ms
+ dune exec --release -- test/sum_array.exe -r 10 -n 100000 -c 1000 -d 8
# Sum of int array of size: 100000 | 1000 elements changed in propagation benchmarks | Domains spawned: 8
## Initial computation
Name                              Avg                Median             Runs     Max time           Min time
static-seq-arr-sum                0.2138 ms          0.2149 ms          10       0.2491 ms          0.1981 ms
incr-seq-arr-sum-initial-cons     44.7839 ms         44.3221 ms         10       52.4818 ms         40.04001 ms
incr-par-arr-sum-initial-cons     90.9362 ms         93.5459 ms         10       101.2239 ms        78.1099 ms
js-incr-arr-sum-initial-cons      93.1041 ms         90.3185 ms         10       106.06098 ms       87.4409 ms
current-incr-arr-sum-initial-cons 102.8288 ms        96.1530 ms         10       134.9549 ms        77.7618 ms
## Change propagation
Name                      Avg                Median             Runs     Max time           Min time
incr-par-arr-sum-prop     1.4397 ms          0.9005 ms          10       6.3681 ms          0.7870 ms
js_incr-arr-sum-prop      1.6704 ms          1.6210 ms          10       2.03585 ms         1.2719 ms
incr-seq-arr-sum-prop     2.4501 ms          2.4441 ms          10       2.5792 ms          2.2799 ms
current-incr-arr-sum-prop 22.7845 ms         24.2729 ms         10       26.7581 ms         7.7497 ms


```

## spellcheck

```bash
NUM_DOMAINS=2 RUNS=10 bash bench_runner.sh spellcheck.exe 100 1000 "i+200" 10
+ dune exec --release -- test/spellcheck.exe -r 10 -n 100 -c 10 -d 2
# Min edit distance with 100 random words | 10 words changed during propagation | Domains spawned: 2
## Initial computation
Name                                 Avg                Median             Runs     Max time           Min time
incr-par-spellcheck-initial-cons     5.8892 ms          5.7740 ms          10       7.07602 ms         5.6450 ms
static-par-spellcheck                10.1355 ms         10.3044 ms         10       11.05117 ms        7.2569 ms
js-incr-spellcheck-initial-cons      17.2042 ms         17.1850 ms         10       17.4529 ms         16.9751 ms
incr-seq-spellcheck-initial-cons     17.2472 ms         17.1949 ms         10       17.8940 ms         16.9301 ms
current-incr-spellcheck-initial-cons 17.3069 ms         17.2764 ms         10       17.5740 ms         17.09699 ms
static-seq-spellcheck                17.8436 ms         17.2320 ms         10       23.3149 ms         16.7310 ms
## Change propagation
Name                                Avg                Median             Runs     Max time           Min time
incr-par-spellcheck-change-prop     0.6994 ms          0.6979 ms          10       0.7550 ms          0.6818 ms
js-incr-spellcheck-change-prop      1.8567 ms          1.9044 ms          10       2.01082 ms         1.5981 ms
current-incr-spellcheck-change-prop 1.8734 ms          1.9085 ms          10       1.9750 ms          1.6751 ms
incr-seq-spellcheck-change-prop     1.8919 ms          1.9048 ms          10       2.01010 ms         1.7409 ms
+ dune exec --release -- test/spellcheck.exe -r 10 -n 300 -c 30 -d 2
# Min edit distance with 300 random words | 30 words changed during propagation | Domains spawned: 2
## Initial computation
Name                                 Avg                Median             Runs     Max time           Min time
incr-par-spellcheck-initial-cons     17.1308 ms         17.1530 ms         10       17.2879 ms         16.8900 ms
static-par-spellcheck                19.5385 ms         17.7345 ms         10       25.8569 ms         17.4160 ms
static-seq-spellcheck                51.9921 ms         51.9250 ms         10       52.6990 ms         51.6831 ms
incr-seq-spellcheck-initial-cons     52.01640 ms        52.03199 ms        10       52.4821 ms         51.6278 ms
js-incr-spellcheck-initial-cons      52.2979 ms         52.1850 ms         10       52.9270 ms         52.01983 ms
current-incr-spellcheck-initial-cons 52.3137 ms         52.2409 ms         10       52.7019 ms         51.7439 ms
## Change propagation
Name                                Avg                Median             Runs     Max time           Min time
incr-par-spellcheck-change-prop     1.7633 ms          1.7559 ms          10       1.8930 ms          1.7240 ms
js-incr-spellcheck-change-prop      4.9288 ms          4.9719 ms          10       5.3470 ms          4.6589 ms
incr-seq-spellcheck-change-prop     5.06198 ms         5.1469 ms          10       5.3269 ms          4.5669 ms
current-incr-spellcheck-change-prop 5.1526 ms          5.1430 ms          10       5.6319 ms          4.8959 ms
+ dune exec --release -- test/spellcheck.exe -r 10 -n 500 -c 50 -d 2
# Min edit distance with 500 random words | 50 words changed during propagation | Domains spawned: 2
## Initial computation
Name                                 Avg                Median             Runs     Max time           Min time
incr-par-spellcheck-initial-cons     28.4714 ms         28.4429 ms         10       28.6519 ms         28.2881 ms
static-par-spellcheck                29.06715 ms        29.02197 ms        10       29.5188 ms         28.6319 ms
js-incr-spellcheck-initial-cons      86.6051 ms         86.5210 ms         10       87.3398 ms         85.8700 ms
static-seq-spellcheck                86.6730 ms         86.6889 ms         10       87.9838 ms         85.5929 ms
incr-seq-spellcheck-initial-cons     87.5356 ms         87.7619 ms         10       88.9220 ms         86.4140 ms
current-incr-spellcheck-initial-cons 88.3260 ms         88.3450 ms         10       88.9549 ms         87.4719 ms
## Change propagation
Name                                Avg                Median             Runs     Max time           Min time
incr-par-spellcheck-change-prop     2.8952 ms          2.9180 ms          10       3.04818 ms         2.6900 ms
incr-seq-spellcheck-change-prop     8.4195 ms          8.5089 ms          10       8.8720 ms          7.7278 ms
js-incr-spellcheck-change-prop      8.4744 ms          8.5150 ms          10       9.05394 ms         7.7319 ms
current-incr-spellcheck-change-prop 8.5484 ms          8.3799 ms          10       9.1800 ms          8.2151 ms
+ dune exec --release -- test/spellcheck.exe -r 10 -n 700 -c 70 -d 2
# Min edit distance with 700 random words | 70 words changed during propagation | Domains spawned: 2
## Initial computation
Name                                 Avg                Median             Runs     Max time           Min time
incr-par-spellcheck-initial-cons     39.9161 ms         39.9035 ms         10       40.3161 ms         39.5750 ms
static-par-spellcheck                40.8079 ms         40.7215 ms         10       41.4099 ms         40.3320 ms
js-incr-spellcheck-initial-cons      121.6321 ms        121.6064 ms        10       122.4889 ms        120.9120 ms
static-seq-spellcheck                122.6576 ms        120.8009 ms        10       137.8748 ms        120.3269 ms
current-incr-spellcheck-initial-cons 122.8434 ms        122.7409 ms        10       124.3529 ms        121.9580 ms
incr-seq-spellcheck-initial-cons     124.8114 ms        124.5274 ms        10       128.1781 ms        123.1849 ms
## Change propagation
Name                                Avg                Median             Runs     Max time           Min time
incr-par-spellcheck-change-prop     3.9643 ms          3.9809 ms          10       4.07004 ms         3.7839 ms
current-incr-spellcheck-change-prop 11.6925 ms         11.6099 ms         10       12.3519 ms         11.1179 ms
js-incr-spellcheck-change-prop      11.7558 ms         11.8150 ms         10       12.1979 ms         11.1269 ms
incr-seq-spellcheck-change-prop     12.07625 ms        12.02750 ms        10       12.8688 ms         11.5270 ms
+ dune exec --release -- test/spellcheck.exe -r 10 -n 900 -c 90 -d 2
# Min edit distance with 900 random words | 90 words changed during propagation | Domains spawned: 2
## Initial computation
Name                                 Avg                Median             Runs     Max time           Min time
incr-par-spellcheck-initial-cons     51.3663 ms         51.3859 ms         10       51.8610 ms         50.7860 ms
static-par-spellcheck                54.3643 ms         52.2835 ms         10       72.8318 ms         51.9328 ms
static-seq-spellcheck                155.4786 ms        155.2435 ms        10       157.9661 ms        154.3970 ms
js-incr-spellcheck-initial-cons      156.1139 ms        156.06403 ms       10       156.9910 ms        154.9751 ms
incr-seq-spellcheck-initial-cons     156.6143 ms        156.6610 ms        10       157.6309 ms        155.6329 ms
current-incr-spellcheck-initial-cons 158.1936 ms        158.1754 ms        10       159.2440 ms        156.6731 ms
## Change propagation
Name                                Avg                Median             Runs     Max time           Min time
incr-par-spellcheck-change-prop     5.08201 ms         5.1200 ms          10       5.2320 ms          4.8439 ms
incr-seq-spellcheck-change-prop     15.04504 ms        14.9834 ms         10       15.8939 ms         14.5618 ms
js-incr-spellcheck-change-prop      15.06490 ms        15.04540 ms        10       15.5160 ms         14.6591 ms
current-incr-spellcheck-change-prop 15.2727 ms         15.3509 ms         10       15.9108 ms         14.6951 ms


NUM_DOMAINS=4 RUNS=10 bash bench_runner.sh spellcheck.exe 100 1000 "i+200" 10
+ dune exec --release -- test/spellcheck.exe -r 10 -n 100 -c 10 -d 4
# Min edit distance with 100 random words | 10 words changed during propagation | Domains spawned: 4
## Initial computation
Name                                 Avg                Median             Runs     Max time           Min time
incr-par-spellcheck-initial-cons     4.3101 ms          4.3004 ms          10       4.4190 ms          4.2569 ms
static-par-spellcheck                4.4573 ms          4.3131 ms          10       5.2640 ms          4.2579 ms
js-incr-spellcheck-initial-cons      17.3069 ms         17.2654 ms         10       17.7841 ms         17.02904 ms
current-incr-spellcheck-initial-cons 17.3123 ms         17.2669 ms         10       17.8189 ms         17.03405 ms
incr-seq-spellcheck-initial-cons     17.3390 ms         17.2574 ms         10       17.9309 ms         17.07696 ms
static-seq-spellcheck                17.5894 ms         17.3720 ms         10       19.5660 ms         17.1411 ms
## Change propagation
Name                                Avg                Median             Runs     Max time           Min time
incr-par-spellcheck-change-prop     0.6173 ms          0.6124 ms          10       0.6639 ms          0.5600 ms
incr-seq-spellcheck-change-prop     1.9188 ms          1.9218 ms          10       2.3088 ms          1.6880 ms
current-incr-spellcheck-change-prop 2.1297 ms          2.1754 ms          10       2.3338 ms          1.7890 ms
js-incr-spellcheck-change-prop      2.1323 ms          2.1619 ms          10       2.3281 ms          1.9078 ms
+ dune exec --release -- test/spellcheck.exe -r 10 -n 300 -c 30 -d 4
# Min edit distance with 300 random words | 30 words changed during propagation | Domains spawned: 4
## Initial computation
Name                                 Avg                Median             Runs     Max time           Min time
incr-par-spellcheck-initial-cons     12.8582 ms         12.7509 ms         10       13.9458 ms         12.5510 ms
static-par-spellcheck                13.1870 ms         13.2555 ms         10       13.4661 ms         12.8819 ms
static-seq-spellcheck                52.2874 ms         52.2680 ms         10       53.1480 ms         51.3629 ms
incr-seq-spellcheck-initial-cons     52.3411 ms         52.4073 ms         10       52.7298 ms         51.8009 ms
js-incr-spellcheck-initial-cons      52.4954 ms         52.5349 ms         10       52.8750 ms         51.9769 ms
current-incr-spellcheck-initial-cons 52.5297 ms         52.5035 ms         10       53.2848 ms         51.7880 ms
## Change propagation
Name                                Avg                Median             Runs     Max time           Min time
incr-par-spellcheck-change-prop     1.3709 ms          1.3734 ms          10       1.5590 ms          1.2481 ms
js-incr-spellcheck-change-prop      5.01198 ms         4.9440 ms          10       5.3148 ms          4.5440 ms
incr-seq-spellcheck-change-prop     5.09688 ms         5.1009 ms          10       5.2759 ms          4.8739 ms
current-incr-spellcheck-change-prop 5.1270 ms          5.1270 ms          10       5.5689 ms          4.5750 ms
+ dune exec --release -- test/spellcheck.exe -r 10 -n 500 -c 50 -d 4
# Min edit distance with 500 random words | 50 words changed during propagation | Domains spawned: 4
## Initial computation
Name                                 Avg                Median             Runs     Max time           Min time
incr-par-spellcheck-initial-cons     21.2518 ms         21.002650 ms       10       22.2299 ms         20.8868 ms
static-par-spellcheck                21.6728 ms         21.5371 ms         10       22.3748 ms         21.4269 ms
js-incr-spellcheck-initial-cons      87.3715 ms         87.1980 ms         10       88.1159 ms         86.9641 ms
incr-seq-spellcheck-initial-cons     87.5171 ms         87.3270 ms         10       88.7010 ms         86.5991 ms
static-seq-spellcheck                87.8555 ms         87.6874 ms         10       89.9889 ms         86.4470 ms
current-incr-spellcheck-initial-cons 89.3717 ms         87.8876 ms         10       102.3061 ms        87.4149 ms
## Change propagation
Name                                Avg                Median             Runs     Max time           Min time
incr-par-spellcheck-change-prop     2.2040 ms          2.1699 ms          10       2.4690 ms          2.1369 ms
incr-seq-spellcheck-change-prop     8.5423 ms          8.5690 ms          10       9.001016 ms        8.06283 ms
js-incr-spellcheck-change-prop      8.5632 ms          8.5984 ms          10       8.9950 ms          8.1558 ms
current-incr-spellcheck-change-prop 8.6794 ms          8.6815 ms          10       9.3688 ms          7.8868 ms
+ dune exec --release -- test/spellcheck.exe -r 10 -n 700 -c 70 -d 4
# Min edit distance with 700 random words | 70 words changed during propagation | Domains spawned: 4
## Initial computation
Name                                 Avg                Median             Runs     Max time           Min time
incr-par-spellcheck-initial-cons     29.4229 ms         29.4021 ms         10       29.8941 ms         29.1731 ms
static-par-spellcheck                30.6057 ms         30.5309 ms         10       31.08501 ms        30.2948 ms
incr-seq-spellcheck-initial-cons     122.4749 ms        122.4300 ms        10       123.4340 ms        121.3569 ms
current-incr-spellcheck-initial-cons 122.8080 ms        122.9050 ms        10       123.7781 ms        121.1569 ms
js-incr-spellcheck-initial-cons      123.9639 ms        122.4925 ms        10       137.9981 ms        122.006893 ms
static-seq-spellcheck                125.3062 ms        123.6521 ms        10       140.5730 ms        122.4889 ms
## Change propagation
Name                                Avg                Median             Runs     Max time           Min time
incr-par-spellcheck-change-prop     2.9666 ms          2.9275 ms          10       3.1790 ms          2.7971 ms
js-incr-spellcheck-change-prop      11.6753 ms         11.7729 ms         10       12.1538 ms         11.06500 ms
incr-seq-spellcheck-change-prop     11.8270 ms         11.7805 ms         10       13.1428 ms         10.9879 ms
current-incr-spellcheck-change-prop 12.4383 ms         12.2175 ms         10       14.2388 ms         11.7380 ms
+ dune exec --release -- test/spellcheck.exe -r 10 -n 900 -c 90 -d 4
# Min edit distance with 900 random words | 90 words changed during propagation | Domains spawned: 4
## Initial computation
Name                                 Avg                Median             Runs     Max time           Min time
incr-par-spellcheck-initial-cons     38.01569 ms        37.7855 ms         10       39.01696 ms        37.6911 ms
static-par-spellcheck                40.4181 ms         39.1995 ms         10       48.7871 ms         38.8808 ms
js-incr-spellcheck-initial-cons      157.1817 ms        157.01293 ms       10       158.08987 ms       156.5198 ms
incr-seq-spellcheck-initial-cons     157.3856 ms        157.2179 ms        10       159.1608 ms        156.4118 ms
static-seq-spellcheck                158.3600 ms        156.7181 ms        10       172.9512 ms        155.2131 ms
current-incr-spellcheck-initial-cons 158.6482 ms        158.6275 ms        10       159.4908 ms        158.1010 ms
## Change propagation
Name                                Avg                Median             Runs     Max time           Min time
incr-par-spellcheck-change-prop     3.8005 ms          3.7419 ms          10       4.3802 ms          3.6909 ms
incr-seq-spellcheck-change-prop     15.4700 ms         15.4529 ms         10       15.8469 ms         15.2399 ms
current-incr-spellcheck-change-prop 15.5609 ms         15.5315 ms         10       16.2429 ms         15.002012 ms
js-incr-spellcheck-change-prop      15.6973 ms         15.4343 ms         10       18.8419 ms         14.7271 ms


NUM_DOMAINS=6 RUNS=10 bash bench_runner.sh spellcheck.exe 100 1000 "i+200" 10
+ dune exec --release -- test/spellcheck.exe -r 10 -n 100 -c 10 -d 6
# Min edit distance with 100 random words | 10 words changed during propagation | Domains spawned: 6
## Initial computation
Name                                 Avg                Median             Runs     Max time           Min time
incr-par-spellcheck-initial-cons     4.02603 ms         4.01794 ms         10       4.09698 ms         3.9808 ms
static-par-spellcheck                4.04400 ms         4.003047 ms        10       4.3189 ms          3.9870 ms
js-incr-spellcheck-initial-cons      17.3110 ms         17.3209 ms         10       17.5139 ms         17.04382 ms
incr-seq-spellcheck-initial-cons     17.4164 ms         17.3759 ms         10       18.2390 ms         17.03596 ms
current-incr-spellcheck-initial-cons 17.4537 ms         17.4314 ms         10       17.9710 ms         17.1468 ms
static-seq-spellcheck                17.6665 ms         17.4134 ms         10       19.7961 ms         17.2109 ms
## Change propagation
Name                                Avg                Median             Runs     Max time           Min time
incr-par-spellcheck-change-prop     0.5757 ms          0.6034 ms          10       0.6160 ms          0.3449 ms
js-incr-spellcheck-change-prop      1.7906 ms          1.7440 ms          10       1.8939 ms          1.7049 ms
current-incr-spellcheck-change-prop 1.9812 ms          1.9030 ms          10       2.7868 ms          1.5921 ms
incr-seq-spellcheck-change-prop     2.2216 ms          2.2445 ms          10       2.3529 ms          1.8830 ms
+ dune exec --release -- test/spellcheck.exe -r 10 -n 300 -c 30 -d 6
# Min edit distance with 300 random words | 30 words changed during propagation | Domains spawned: 6
## Initial computation
Name                                 Avg                Median             Runs     Max time           Min time
incr-par-spellcheck-initial-cons     12.1267 ms         12.03703 ms        10       12.9258 ms         11.9922 ms
static-par-spellcheck                12.7874 ms         12.7805 ms         10       13.1969 ms         12.4549 ms
incr-seq-spellcheck-initial-cons     52.4034 ms         52.3175 ms         10       53.4529 ms         51.6421 ms
js-incr-spellcheck-initial-cons      52.4900 ms         52.4334 ms         10       52.9179 ms         52.2320 ms
static-seq-spellcheck                52.6049 ms         52.2869 ms         10       53.8990 ms         51.8500 ms
current-incr-spellcheck-initial-cons 52.9081 ms         52.8455 ms         10       54.5959 ms         52.2079 ms
## Change propagation
Name                                Avg                Median             Runs     Max time           Min time
incr-par-spellcheck-change-prop     1.3060 ms          1.2625 ms          10       1.5809 ms          1.2469 ms
incr-seq-spellcheck-change-prop     5.3142 ms          5.3035 ms          10       5.6498 ms          4.7519 ms
js-incr-spellcheck-change-prop      5.3184 ms          5.3510 ms          10       5.5239 ms          4.8060 ms
current-incr-spellcheck-change-prop 5.4279 ms          5.4600 ms          10       5.7229 ms          5.02014 ms
+ dune exec --release -- test/spellcheck.exe -r 10 -n 500 -c 50 -d 6
# Min edit distance with 500 random words | 50 words changed during propagation | Domains spawned: 6
## Initial computation
Name                                 Avg                Median             Runs     Max time           Min time
incr-par-spellcheck-initial-cons     20.1865 ms         20.1270 ms         10       21.1079 ms         19.9489 ms
static-par-spellcheck                21.3150 ms         21.2374 ms         10       22.2761 ms         20.6508 ms
js-incr-spellcheck-initial-cons      87.05434 ms        87.1075 ms         10       87.8190 ms         86.1721 ms
static-seq-spellcheck                87.2174 ms         87.06641 ms        10       88.9110 ms         86.1899 ms
incr-seq-spellcheck-initial-cons     87.2682 ms         87.2849 ms         10       87.9311 ms         86.5149 ms
current-incr-spellcheck-initial-cons 89.01612 ms        87.6789 ms         10       99.7879 ms         86.5888 ms
## Change propagation
Name                                Avg                Median             Runs     Max time           Min time
incr-par-spellcheck-change-prop     2.05461 ms         2.1215 ms          10       2.1700 ms          1.8770 ms
js-incr-spellcheck-change-prop      8.7450 ms          8.7499 ms          10       9.2961 ms          8.1200 ms
incr-seq-spellcheck-change-prop     8.8056 ms          8.8208 ms          10       9.2179 ms          8.4350 ms
current-incr-spellcheck-change-prop 8.9137 ms          8.9144 ms          10       9.3929 ms          8.3818 ms
+ dune exec --release -- test/spellcheck.exe -r 10 -n 700 -c 70 -d 6
# Min edit distance with 700 random words | 70 words changed during propagation | Domains spawned: 6
## Initial computation
Name                                 Avg                Median             Runs     Max time           Min time
incr-par-spellcheck-initial-cons     28.2390 ms         28.03301 ms        10       29.06799 ms        27.8968 ms
static-par-spellcheck                29.5993 ms         29.4915 ms         10       30.4729 ms         29.1478 ms
static-seq-spellcheck                122.2753 ms        122.05505 ms       10       124.7668 ms        120.8000 ms
incr-seq-spellcheck-initial-cons     122.7066 ms        122.6786 ms        10       123.5480 ms        122.1220 ms
js-incr-spellcheck-initial-cons      122.9716 ms        122.9594 ms        10       123.9869 ms        122.2150 ms
current-incr-spellcheck-initial-cons 123.2116 ms        123.3024 ms        10       124.1970 ms        122.1480 ms
## Change propagation
Name                                Avg                Median             Runs     Max time           Min time
incr-par-spellcheck-change-prop     2.8710 ms          2.8214 ms          10       3.1340 ms          2.7339 ms
current-incr-spellcheck-change-prop 11.9496 ms         12.08698 ms        10       12.3410 ms         11.09099 ms
js-incr-spellcheck-change-prop      12.1297 ms         12.1459 ms         10       12.6490 ms         11.4490 ms
incr-seq-spellcheck-change-prop     12.2534 ms         12.1525 ms         10       12.7990 ms         11.8560 ms
+ dune exec --release -- test/spellcheck.exe -r 10 -n 900 -c 90 -d 6
# Min edit distance with 900 random words | 90 words changed during propagation | Domains spawned: 6
## Initial computation
Name                                 Avg                Median             Runs     Max time           Min time
incr-par-spellcheck-initial-cons     36.2284 ms         35.8194 ms         10       38.8197 ms         35.6969 ms
static-par-spellcheck                38.2981 ms         38.2000 ms         10       39.6230 ms         37.4350 ms
static-seq-spellcheck                156.9859 ms        156.8440 ms        10       158.7150 ms        156.1899 ms
js-incr-spellcheck-initial-cons      157.6086 ms        157.05442 ms       10       161.6730 ms        155.3158 ms
current-incr-spellcheck-initial-cons 157.9089 ms        158.01596 ms       10       158.8299 ms        156.7518 ms
incr-seq-spellcheck-initial-cons     160.4513 ms        160.4654 ms        10       160.8610 ms        159.9261 ms
## Change propagation
Name                                Avg                Median             Runs     Max time           Min time
incr-par-spellcheck-change-prop     3.6260 ms          3.6900 ms          10       3.7779 ms          3.3898 ms
js-incr-spellcheck-change-prop      15.4047 ms         15.5880 ms         10       15.8381 ms         14.5409 ms
current-incr-spellcheck-change-prop 15.5549 ms         15.6511 ms         10       15.9580 ms         15.005111 ms
incr-seq-spellcheck-change-prop     15.6901 ms         15.7129 ms         10       16.05105 ms        15.2199 ms


NUM_DOMAINS=8 RUNS=10 bash bench_runner.sh spellcheck.exe 100 1000 "i+200" 10
+ dune exec --release -- test/spellcheck.exe -r 10 -n 100 -c 10 -d 8
# Min edit distance with 100 random words | 10 words changed during propagation | Domains spawned: 8
## Initial computation
Name                                 Avg                Median             Runs     Max time           Min time
incr-par-spellcheck-initial-cons     4.8731 ms          4.3889 ms          10       6.3591 ms          4.02688 ms
static-par-spellcheck                5.01255 ms         4.5099 ms          10       7.6718 ms          3.9830 ms
current-incr-spellcheck-initial-cons 17.6030 ms         17.6090 ms         10       17.8539 ms         17.4479 ms
incr-seq-spellcheck-initial-cons     17.6465 ms         17.6839 ms         10       17.9049 ms         17.3258 ms
js-incr-spellcheck-initial-cons      17.7450 ms         17.6885 ms         10       18.5110 ms         17.4641 ms
static-seq-spellcheck                19.1824 ms         17.7614 ms         10       27.4350 ms         17.4558 ms
## Change propagation
Name                                Avg                Median             Runs     Max time           Min time
incr-par-spellcheck-change-prop     1.2666 ms          0.6629 ms          10       3.08585 ms         0.6082 ms
js-incr-spellcheck-change-prop      1.8805 ms          1.8359 ms          10       2.4290 ms          1.6000 ms
incr-seq-spellcheck-change-prop     1.9634 ms          1.9505 ms          10       2.2389 ms          1.5449 ms
current-incr-spellcheck-change-prop 2.03158 ms         1.9410 ms          10       2.4077 ms          1.7402 ms
+ dune exec --release -- test/spellcheck.exe -r 10 -n 300 -c 30 -d 8
# Min edit distance with 300 random words | 30 words changed during propagation | Domains spawned: 8
## Initial computation
Name                                 Avg                Median             Runs     Max time           Min time
incr-par-spellcheck-initial-cons     14.1120 ms         14.05286 ms        10       16.3471 ms         12.2749 ms
static-par-spellcheck                15.6443 ms         14.4070 ms         10       23.2729 ms         12.5532 ms
js-incr-spellcheck-initial-cons      53.7241 ms         53.7179 ms         10       55.07206 ms        52.9739 ms
incr-seq-spellcheck-initial-cons     57.4761 ms         54.8244 ms         10       71.5570 ms         52.9580 ms
current-incr-spellcheck-initial-cons 60.8799 ms         57.3738 ms         10       84.7110 ms         53.8070 ms
static-seq-spellcheck                63.05491 ms        61.8150 ms         10       77.3391 ms         52.5720 ms
## Change propagation
Name                                Avg                Median             Runs     Max time           Min time
incr-par-spellcheck-change-prop     1.9424 ms          1.3214 ms          10       3.9010 ms          1.2300 ms
js-incr-spellcheck-change-prop      5.2042 ms          5.2268 ms          10       5.5770 ms          4.7609 ms
incr-seq-spellcheck-change-prop     5.2068 ms          5.2069 ms          10       5.6180 ms          4.8329 ms
current-incr-spellcheck-change-prop 5.2219 ms          5.07843 ms         10       6.03604 ms         4.8348 ms
+ dune exec --release -- test/spellcheck.exe -r 10 -n 500 -c 50 -d 8
# Min edit distance with 500 random words | 50 words changed during propagation | Domains spawned: 8
## Initial computation
Name                                 Avg                Median             Runs     Max time           Min time
static-par-spellcheck                22.4427 ms         22.09401 ms        10       24.7778 ms         21.3508 ms
incr-par-spellcheck-initial-cons     23.6734 ms         23.8753 ms         10       27.2450 ms         21.4710 ms
js-incr-spellcheck-initial-cons      90.6993 ms         88.8425 ms         10       96.1871 ms         87.4428 ms
current-incr-spellcheck-initial-cons 92.7312 ms         89.4919 ms         10       112.5800 ms        88.2158 ms
incr-seq-spellcheck-initial-cons     94.6022 ms         92.07296 ms        10       108.2060 ms        88.8731 ms
static-seq-spellcheck                102.8735 ms        102.9160 ms        10       118.7741 ms        88.6828 ms
## Change propagation
Name                                Avg                Median             Runs     Max time           Min time
incr-par-spellcheck-change-prop     2.6285 ms          2.2124 ms          10       6.8049 ms          1.9381 ms
incr-seq-spellcheck-change-prop     8.8262 ms          8.9299 ms          10       9.3059 ms          8.1830 ms
js-incr-spellcheck-change-prop      8.8618 ms          8.7670 ms          10       9.1919 ms          8.5580 ms
current-incr-spellcheck-change-prop 9.03570 ms         9.06836 ms         10       9.5801 ms          8.3498 ms
+ dune exec --release -- test/spellcheck.exe -r 10 -n 700 -c 70 -d 8
# Min edit distance with 700 random words | 70 words changed during propagation | Domains spawned: 8
## Initial computation
Name                                 Avg                Median             Runs     Max time           Min time
incr-par-spellcheck-initial-cons     31.4708 ms         30.8754 ms         10       34.8169 ms         29.2308 ms
static-par-spellcheck                33.1552 ms         32.4999 ms         10       39.06893 ms        29.5970 ms
js-incr-spellcheck-initial-cons      125.1332 ms        124.1599 ms        10       129.4181 ms        123.4500 ms
current-incr-spellcheck-initial-cons 133.1351 ms        127.8324 ms        10       159.1358 ms        125.3778 ms
incr-seq-spellcheck-initial-cons     140.4765 ms        141.6521 ms        10       152.5521 ms        127.01487 ms
static-seq-spellcheck                140.8646 ms        141.3129 ms        10       168.4939 ms        124.2079 ms
## Change propagation
Name                                Avg                Median             Runs     Max time           Min time
incr-par-spellcheck-change-prop     3.9384 ms          3.07607 ms         10       6.6249 ms          2.6299 ms
incr-seq-spellcheck-change-prop     12.1717 ms         12.3095 ms         10       12.7501 ms         11.09600 ms
js-incr-spellcheck-change-prop      12.2398 ms         12.1535 ms         10       13.1640 ms         11.5358 ms
current-incr-spellcheck-change-prop 12.4413 ms         12.4760 ms         10       13.1409 ms         11.6059 ms
+ dune exec --release -- test/spellcheck.exe -r 10 -n 900 -c 90 -d 8
# Min edit distance with 900 random words | 90 words changed during propagation | Domains spawned: 8
## Initial computation
Name                                 Avg                Median             Runs     Max time           Min time
static-par-spellcheck                41.3109 ms         40.2251 ms         10       48.4299 ms         38.9058 ms
incr-par-spellcheck-initial-cons     44.3646 ms         41.5805 ms         10       57.3549 ms         39.3030 ms
js-incr-spellcheck-initial-cons      162.8054 ms        159.3304 ms        10       178.3320 ms        158.08510 ms
current-incr-spellcheck-initial-cons 165.5792 ms        161.4910 ms        10       191.5779 ms        160.5629 ms
static-seq-spellcheck                174.4117 ms        172.1421 ms        10       193.8781 ms        160.5479 ms
incr-seq-spellcheck-initial-cons     177.2042 ms        174.7804 ms        10       212.5329 ms        163.6090 ms
## Change propagation
Name                                Avg                Median             Runs     Max time           Min time
incr-par-spellcheck-change-prop     4.1401 ms          3.7314 ms          10       5.6369 ms          3.3710 ms
js-incr-spellcheck-change-prop      15.7958 ms         15.7979 ms         10       16.2620 ms         15.3849 ms
current-incr-spellcheck-change-prop 15.9505 ms         15.8085 ms         10       17.5991 ms         15.4390 ms
incr-seq-spellcheck-change-prop     16.1463 ms         15.9885 ms         10       18.1920 ms         14.7428 ms
```
