### PR TITLE
fix marking bug

### DIFF
--- a/lib/par_incr.ml
+++ b/lib/par_incr.ml
@@ -131,7 +131,11 @@ let combine (a : 'a t) (b : 'b t) ctx e =
   let lr = Rsp.make_empty `S in
   let x = a ll e in
   let y = b lr e in
-  let xy = Var.empty ~cutoff:Phys_equal ~to_s:Utils.undefined () in
+  let xy =
+    Var.empty ~cutoff:Phys_equal
+      ~to_s:(Utils.combine_to_s (Var.get_to_string x) (Var.get_to_string y))
+      ()
+  in
   let read_fn_xy (type a) : a action -> a = function
     | Update -> Var.set xy (Var.value x, Var.value y)
     | Remove self ->

--- a/lib/rsp.ml
+++ b/lib/rsp.ml
@@ -116,7 +116,6 @@ let[@inline] is_marked c = c != nil_tree && Utils.is_marked c.flags
 let rec propagate_exn comp e =
   let {left; right; fn; flags; _} = comp in
   let masked_flag = Utils.masked flags in
-  comp.flags <- masked_flag;
   if masked_flag = Utils.r_flag then fn Update
   else if masked_flag = Utils.p_flag && is_marked left && is_marked right then
     let _ =
@@ -130,7 +129,8 @@ let rec propagate_exn comp e =
     if masked_flag = Utils.root_flag then Utils.impossible ();
     if is_marked left then propagate_exn left e;
     if is_marked right then propagate_exn right e
-  end
+  end;
+  comp.flags <- masked_flag
 
 let propagate_root comp e =
   if comp == nil_tree then
@@ -139,10 +139,11 @@ let propagate_root comp e =
     let {left; right; flags; par; _} = comp in
     assert (Utils.is_root flags);
     assert (par == nil_tree);
-    if Utils.is_marked comp.flags then
+    if Utils.is_marked comp.flags then (
       e.run (fun () ->
           if is_marked left then propagate_exn left e;
-          if is_marked right then propagate_exn right e)
+          if is_marked right then propagate_exn right e);
+      comp.flags <- Utils.masked flags)
   end
 
 let[@inline] set_and_get_exn t dir child =


### PR DESCRIPTION
I tried to make `propagate_exn` end with tail-call by marking the comp_tree node clean at the start before propagating it's left and right branches. But I didn't realize that the node could be marked dirty again when propagation of left and right branch is happening. So, I'm fixing that. 

This bug wouldn't slow down the program normally. But when we would run propagate on a non-dirty tree, it would do extra work for no reason. 


For a program(using sum_range function from benchmarks) :
```ocaml
let count = 3
let arr = Array.init count (( + ) 1) (* [1,2,3] *)
let var_arr = Array.map (Par_incr.Var.create ~to_s:Int.to_string) arr
let t_arr = Array.map Par_incr.Var.watch var_arr
let executor =
  Par_incr.
    {
      run = (fun f -> f ());
      par_do =
        (fun l r ->
          let lres = l () in
          (lres, r ()));
    }
let () =
  let seq_comp = Par_incr.run ~executor (sum_range ~lo:0 ~hi:count t_arr) in
  Par_incr.dump_tree "sum-range.d2" seq_comp;
  Var.set var_arr.(1) 10;
  Par_incr.dump_tree "sum-range-after-change.d2" seq_comp;
  Par_incr.propagate seq_comp;
  Par_incr.dump_tree "sum-range-after-prop.d2" seq_comp;
  Par_incr.destroy_comp seq_comp

```


In main, after propagation, tree would look like:

![image](https://github.com/ocaml-multicore/par_incr/assets/38459660/951d51f2-9042-4f83-b435-84423d43d605)

But it should be like:

![image](https://github.com/ocaml-multicore/par_incr/assets/38459660/3d036f53-3a46-4dbb-ac1e-6c2c7eefdf9f)


- I've also made combine's Show action to combine Show action of its constituents