### PR TITLE
Build on OCaml 4

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -61,3 +61,29 @@ jobs:
 
       - name: Test
         run: opam exec -- dune runtest
+
+  build-4_14_x:
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+        ocaml-compiler:
+          - 4.14.x
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Use OCaml ${{ matrix.ocaml-compiler }}
+        uses: ocaml/setup-ocaml@v2
+        with:
+          ocaml-compiler: ${{ matrix.ocaml-compiler }}
+
+      - name: Install dependencies
+        run: opam install . --deps-only
+
+      - name: Build
+        run: opam exec -- dune build

--- a/bench/dune
+++ b/bench/dune
@@ -1,4 +1,7 @@
 (tests
  (names merge_sort filter sum_array spellcheck rabin_karp)
- (build_if %{lib-available:incremental})
+ (build_if
+  (and
+   %{lib-available:incremental}
+   (>= %{ocaml_version} 5.0.0)))
  (libraries unix par_incr domainslib current_incr incremental))

--- a/dune
+++ b/dune
@@ -1,5 +1,7 @@
 (mdx
  (package par_incr)
+ (enabled_if
+  (>= %{ocaml_version} 5.0.0))
  (deps
   (package par_incr))
  (files README.md))

--- a/dune-project
+++ b/dune-project
@@ -19,8 +19,7 @@
  (synopsis "Parallel Self Adjusting Computation")
  (description "A library for incremental computation, with support for parallelism")
  (depends
-  (ocaml (>= "5.0"))
-  dune
+  (ocaml (>= "4.14.0"))
   (domainslib (and (>= "0.5.0") :with-test ))
   (alcotest (and (>= "1.7.0") :with-test ))
   (mdx (and (>= "2.3.0") :with-test ))

--- a/par_incr.opam
+++ b/par_incr.opam
@@ -11,8 +11,8 @@ homepage: "https://github.com/ocaml-multicore/par_incr"
 doc: "https://ocaml-multicore.github.io/par_incr/par_incr/index.html"
 bug-reports: "https://github.com/ocaml-multicore/par_incr/issues"
 depends: [
-  "ocaml" {>= "5.0"}
   "dune" {>= "3.9"}
+  "ocaml" {>= "4.14.0"}
   "domainslib" {>= "0.5.0" & with-test}
   "alcotest" {>= "1.7.0" & with-test}
   "mdx" {>= "2.3.0" & with-test}

--- a/test/dune
+++ b/test/dune
@@ -1,3 +1,5 @@
 (tests
  (names incr_test)
- (libraries unix par_incr domainslib current_incr alcotest))
+ (build_if
+  (>= %{ocaml_version} 5.0.0))
+ (libraries par_incr domainslib alcotest))


### PR DESCRIPTION
The Par_incr library doesn't actually depend on OCaml 5+ only features.  This PR enables Par_incr to be built and used on OCaml 4.14+.

- OCaml 4.12.0 added the `Atomic` module.
- OCaml 4.14.0 added the `Out_channel` module.

It would be possible to port to earlier 4.x versions by avoiding some of the Stdlib features or by using shims.